### PR TITLE
fix: Update conversion errors

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -307,7 +307,7 @@ impl FromNapiValue for Wrap<ClosedWindow> {
             "right" => ClosedWindow::Right,
             _ => {
                 return Err(napi::Error::from_reason(
-                    "closed should be any of {'none', 'left', 'right'}".to_owned(),
+                    "closed should be any of {'none', 'left', 'right', 'both'}".to_owned(),
                 ))
             }
         };
@@ -327,7 +327,7 @@ impl FromNapiValue for Wrap<RankMethod> {
             "random" => RankMethod::Random,
             _ => {
                 return Err(napi::Error::from_reason(
-                    "use one of 'avg, min, max, dense, ordinal'".to_owned(),
+                    "use one of {'average', 'min', 'max', 'dense', 'ordinal', 'random'}".to_owned(),
                 ))
             }
         };
@@ -371,7 +371,7 @@ impl FromNapiValue for Wrap<UniqueKeepStrategy> {
             "last" => UniqueKeepStrategy::Last,
             _ => {
                 return Err(napi::Error::from_reason(
-                    "use one of 'first, last'".to_owned(),
+                    "use one of {'first', 'last'}".to_owned(),
                 ))
             }
         };
@@ -387,7 +387,7 @@ impl FromNapiValue for Wrap<NullStrategy> {
             "propagate" => NullStrategy::Propagate,
             _ => {
                 return Err(napi::Error::from_reason(
-                    "use one of 'ignore', 'propagate'".to_owned(),
+                    "use one of {'ignore', 'propagate'}".to_owned(),
                 ))
             }
         };
@@ -403,7 +403,7 @@ impl FromNapiValue for Wrap<NullBehavior> {
             "ignore" => NullBehavior::Ignore,
             _ => {
                 return Err(napi::Error::from_reason(
-                    "use one of 'drop', 'ignore'".to_owned(),
+                    "use one of {'drop', 'ignore'}".to_owned(),
                 ))
             }
         };

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -926,7 +926,7 @@ impl FromJsUnknown for i64 {
                 let s: JsNumber = val.try_into()?;
                 s.try_into()
             }
-            dt => Err(JsPolarsErr::Other(format!("cannot cast {} to u64", dt)).into()),
+            dt => Err(JsPolarsErr::Other(format!("cannot cast {} to i64", dt)).into()),
         }
     }
 }

--- a/src/lazy/dataframe.rs
+++ b/src/lazy/dataframe.rs
@@ -671,7 +671,6 @@ pub fn scan_ipc(path: String, options: ScanIPCOptions) -> napi::Result<JsLazyFra
     Ok(lf.into())
 }
 
-
 #[napi(object)]
 pub struct JsonScanOptions {
     pub infer_schema_length: Option<i64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ pub mod lazy;
 pub mod list_construction;
 pub mod prelude;
 pub mod series;
-pub mod utils;
 pub mod set;
+pub mod utils;
 
 pub use polars_core;
 

--- a/src/series.rs
+++ b/src/series.rs
@@ -1158,7 +1158,6 @@ impl JsSeries {
     }
 }
 
-
 macro_rules! impl_set_with_mask_wrap {
     ($name:ident, $native:ty, $cast:ident) => {
         #[napi]


### PR DESCRIPTION
## Description

Updated error messages:
- to mirror the match blocks
- to be consistent with `{}` around the enum values in the message

