### PR TITLE
feat: pl.element() and additional dtype constructors

### DIFF
--- a/__tests__/lazy_functions.test.ts
+++ b/__tests__/lazy_functions.test.ts
@@ -440,4 +440,14 @@ describe("lazy functions", () => {
     const actual = df.select(pl.tail(col("a"), 2)).getColumn("a");
     expect(actual).toSeriesEqual(expected);
   });
+  test("element", () => {
+    const df = pl.DataFrame({
+      a: [[1,2], [3,4], [5,6]],
+    })
+    const expected = pl.DataFrame({
+      a: [[2,4], [6,8], [10,12]],
+    })
+    const actual = df.select(pl.col("a").lst.eval(pl.element().mul(2)))
+    expect(actual).toFrameEqual(expected)
+  })
 });

--- a/__tests__/lazy_functions.test.ts
+++ b/__tests__/lazy_functions.test.ts
@@ -442,12 +442,12 @@ describe("lazy functions", () => {
   });
   test("element", () => {
     const df = pl.DataFrame({
-      a: [[1,2], [3,4], [5,6]],
-    })
+      a: [[1, 2], [3, 4], [5, 6]],
+    });
     const expected = pl.DataFrame({
-      a: [[2,4], [6,8], [10,12]],
-    })
-    const actual = df.select(pl.col("a").lst.eval(pl.element().mul(2)))
-    expect(actual).toFrameEqual(expected)
-  })
+      a: [[2, 4], [6, 8], [10, 12]],
+    });
+    const actual = df.select(pl.col("a").lst.eval(pl.element().mul(2)));
+    expect(actual).toFrameEqual(expected);
+  });
 });

--- a/polars/datatypes/datatype.ts
+++ b/polars/datatypes/datatype.ts
@@ -115,22 +115,25 @@ export abstract class DataType {
   }
 
   toString() {
-    return `${this.identity}.${this.variant}`;
+    if(this.inner) {
+      return `${this.identity}(${this.variant}(${this.inner}))`;
+    } else {
+      return `${this.identity}(${this.variant})`;
+
+    }
   }
   toJSON() {
     const inner = (this as any).inner;
+    
     if (inner) {
       return {
         [this.identity]: {
-          variant: this.variant,
-          inner,
+          [this.variant]: inner[0],
         },
       };
     } else {
       return {
-        [this.identity]: {
-          variant: this.variant,
-        },
+        [this.identity]: this.variant,
       };
     }
   }
@@ -236,8 +239,9 @@ class _Struct extends DataType {
   }
   override toJSON() {
     return {
-      variant: this.variant,
-      fields: this.fields.map(fld => fld.toJSON())
+      [this.identity]: {
+        [this.variant]: this.fields
+      }
     } as any;
   }
 }

--- a/polars/datatypes/datatype.ts
+++ b/polars/datatypes/datatype.ts
@@ -124,7 +124,7 @@ export abstract class DataType {
   }
   toJSON() {
     const inner = (this as any).inner;
-    
+
     if (inner) {
       return {
         [this.identity]: {

--- a/polars/datatypes/field.ts
+++ b/polars/datatypes/field.ts
@@ -8,12 +8,12 @@ export interface Field {
 export class Field {
   constructor(public name: string, public dtype: DataType) { }
   toString() {
-    return `Field("${this.name}": ${this.dtype})`;
+    return `Field("${this.name}", ${this.dtype})`;
   }
   toJSON() {
     return {
       name: this.name,
-      dtype: this.dtype.toString(),
+      dtype: this.dtype,
     };
   }
   [Symbol.for("nodejs.util.inspect.custom")]() {

--- a/polars/index.ts
+++ b/polars/index.ts
@@ -41,6 +41,8 @@ namespace pl {
   export import Datetime = DataType.Datetime;
   export import Time = DataType.Time;
   export import Object = DataType.Object;
+  export import Null = DataType.Null;
+  export import Struct = DataType.Struct;
   export import Categorical = DataType.Categorical;
   export import repeat = func.repeat;
   export import concat = func.concat;
@@ -73,6 +75,7 @@ namespace pl {
   export import count = lazy.count
   export import cov = lazy.cov
   export import exclude = lazy.exclude
+  export import element = lazy.element
   export import first = lazy.first
   export import format = lazy.format
   export import groups = lazy.groups

--- a/polars/lazy/expr.ts
+++ b/polars/lazy/expr.ts
@@ -863,7 +863,7 @@ export const _Expr = (_expr: any): Expr => {
 
       return _Expr(_expr.quantile(quantile, interpolation));
     },
-    rank(method, reverse=false) {
+    rank(method: any = "average", reverse=false) {
       return _Expr(_expr.rank(method?.method ?? method, method?.reverse ?? reverse));
     },
     reinterpret(signed: any = true) {

--- a/polars/lazy/expr/list.ts
+++ b/polars/lazy/expr/list.ts
@@ -60,8 +60,12 @@ export const ExprListFunctions = (_expr: any): ExprList => {
     tail(n = 5) {
       return this.slice(-n, n);
     },
-    eval(expr, parallel) {
-      return wrap("lstEval", expr, parallel);
+    eval(expr, parallel = true) {
+      if (Expr.isExpr(expr)) {
+        return wrap("lstEval", expr._expr, parallel);
+      } else {
+        return wrap("lstEval", expr, parallel);
+      }
     },
     first() {
       return this.get(0);

--- a/polars/lazy/functions.ts
+++ b/polars/lazy/functions.ts
@@ -550,7 +550,7 @@ export function struct(exprs: ExprOrString | ExprOrString[] | Series[]): Expr | 
   *  └─────┴─────┴─────────────┘
  */
 export function element(): Expr {
-  return col(""); 
+  return col("");
 }
 // // export function collect_all() {}
 // // export function all() {} // fold

--- a/polars/lazy/functions.ts
+++ b/polars/lazy/functions.ts
@@ -251,9 +251,13 @@ export function exclude(...columns): Expr {
 }
 
 /** Get the first value. */
+export function first(): Expr
 export function first(column: string): Expr
 export function first<T>(column: Series): T
-export function first<T>(column: string | Series): Expr | T {
+export function first<T>(column?: string | Series): Expr | T {
+  if(!column) {
+    return _Expr(pli.first());
+  }
   if (Series.isSeries(column)) {
     if (column.length) {
       return column.get(0);
@@ -530,7 +534,7 @@ export function struct(exprs: ExprOrString | ExprOrString[] | Series[]): Expr | 
   *
   *  >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
   *  >>> df.withColumn(
-  *  ...     pl.concatList(["a", "b"]).arr.eval(pl.element() * 2).alias("a_b_doubled")
+  *  ...     pl.concatList(["a", "b"]).arr.eval(pl.element().multiplyBy(2)).alias("a_b_doubled")
   *  ... )
   *  shape: (3, 3)
   *  ┌─────┬─────┬─────────────┐
@@ -546,7 +550,7 @@ export function struct(exprs: ExprOrString | ExprOrString[] | Series[]): Expr | 
   *  └─────┴─────┴─────────────┘
  */
 export function element(): Expr {
-  return col("");
+  return col(""); 
 }
 // // export function collect_all() {}
 // // export function all() {} // fold

--- a/polars/shared_traits.ts
+++ b/polars/shared_traits.ts
@@ -488,7 +488,7 @@ export interface ListFunctions<T> {
       │ 3   ┆ 2   ┆ [2.0, 1.0] │
       └─────┴─────┴────────────┘
    */
-  eval(expr: Expr, parallel: boolean): T;
+  eval(expr: Expr, parallel?: boolean): T;
   /** Get the first value of the sublists. */
   first(): T;
   /**


### PR DESCRIPTION
adds `pl.element()`, and dtype constructors`pl.Null`, and `pl.Struct(field)`

also cleans up `DataType` string/js repr a bit.  