### PR TITLE
docs: fix broken link and update join documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Want to know about all the features Polars supports? Read the docs!
 #### Node
 
   * Installation guide: `$ yarn install nodejs-polars`
-  * [Node documentation](https://pola-rs.github.io/nodejs-polars/html/index.html)
+  * [Node documentation](https://pola-rs.github.io/nodejs-polars/)
   * [User guide](https://pola-rs.github.io/polars-book/)
 
 ## Contribution

--- a/polars/dataframe.ts
+++ b/polars/dataframe.ts
@@ -702,7 +702,7 @@ export interface DataFrame
    * @param options.on - Name(s) of the join columns in both DataFrames.
    * @param options.how - Join strategy
    * @param options.suffix - Suffix to append to columns with a duplicate name.
-   * @see {@link JoinOptions}
+   * @see {@link JoinBaseOptions}
    * @example
    * ```
    * >>> df = pl.DataFrame({

--- a/polars/dataframe.ts
+++ b/polars/dataframe.ts
@@ -702,7 +702,7 @@ export interface DataFrame
    * @param options.on - Name(s) of the join columns in both DataFrames.
    * @param options.how - Join strategy
    * @param options.suffix - Suffix to append to columns with a duplicate name.
-   * @see {@link JoinBaseOptions}
+   * @see {@link JoinOptions}
    * @example
    * ```
    * >>> df = pl.DataFrame({

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -184,19 +184,22 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    * @param options.on - Name(s) of the join columns in both DataFrames.
    * @param options.how - Join strategy
    * @param options.suffix - Suffix to append to columns with a duplicate name.
+   * @param options.allowParallel - Allow the physical plan to optionally evaluate the computation of both DataFrames up to the join in parallel.
+   * @param options.forceParallel - Force the physical plan to evaluate the computation of both DataFrames up to the join in parallel.
    * @see {@link LazyJoinOptions}
    * @example
    * ```
-   * >>> df = pl.DataFrame({
-   * >>>   "foo": [1, 2, 3],
-   * >>>   "bar": [6.0, 7.0, 8.0],
-   * >>>   "ham": ['a', 'b', 'c']
-   * >>> })
-   * >>> otherDF = pl.DataFrame({
-   * >>>   "apple": ['x', 'y', 'z'],
-   * >>>   "ham": ['a', 'b', 'd']
-   * >>> })
-   * >>> df.join(otherDF, {on: 'ham', how: 'inner'})
+   * >>> const df = pl.DataFrame({
+   * >>>     foo: [1, 2, 3],
+   * >>>     bar: [6.0, 7.0, 8.0],
+   * >>>     ham: ['a', 'b', 'c'],
+   * >>>   }).lazy()
+   * >>>
+   * >>> const otherDF = pl.DataFrame({
+   * >>>     apple: ['x', 'y', 'z'],
+   * >>>     ham: ['a', 'b', 'd'],
+   * >>>   }).lazy();
+   * >>> const result = await df.join(otherDF, { on: 'ham', how: 'inner' }).collect();
    * shape: (2, 4)
    * ╭─────┬─────┬─────┬───────╮
    * │ foo ┆ bar ┆ ham ┆ apple │

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -176,7 +176,38 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    */
   head(length?: number): LazyDataFrame;
   /**
-   * Add a join operation to the Logical Plan.
+   *  __SQL like joins.__
+   * @param df - DataFrame to join with.
+   * @param options
+   * @param options.leftOn - Name(s) of the left join column(s).
+   * @param options.rightOn - Name(s) of the right join column(s).
+   * @param options.on - Name(s) of the join columns in both DataFrames.
+   * @param options.how - Join strategy
+   * @param options.suffix - Suffix to append to columns with a duplicate name.
+   * @see {@link LazyJoinOptions}
+   * @example
+   * ```
+   * >>> df = pl.DataFrame({
+   * >>>   "foo": [1, 2, 3],
+   * >>>   "bar": [6.0, 7.0, 8.0],
+   * >>>   "ham": ['a', 'b', 'c']
+   * >>> })
+   * >>> otherDF = pl.DataFrame({
+   * >>>   "apple": ['x', 'y', 'z'],
+   * >>>   "ham": ['a', 'b', 'd']
+   * >>> })
+   * >>> df.join(otherDF, {on: 'ham', how: 'inner'})
+   * shape: (2, 4)
+   * ╭─────┬─────┬─────┬───────╮
+   * │ foo ┆ bar ┆ ham ┆ apple │
+   * │ --- ┆ --- ┆ --- ┆ ---   │
+   * │ i64 ┆ f64 ┆ str ┆ str   │
+   * ╞═════╪═════╪═════╪═══════╡
+   * │ 1   ┆ 6   ┆ "a" ┆ "x"   │
+   * ├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+   * │ 2   ┆ 7   ┆ "b" ┆ "y"   │
+   * ╰─────┴─────┴─────┴───────╯
+   * ```
    */
   join(
     other: LazyDataFrame,


### PR DESCRIPTION
If you have any suggestions how to best check / generate the tsdoc locally, I'm happy to learn.
For instance I think the @link of the join in dataframe should be JoinBaseOptions instead of JoinOptions but it did not find a easy way to check this myself