### PR TITLE
Allow to mixing series and expressions in withColumns

### DIFF
--- a/polars/dataframe.ts
+++ b/polars/dataframe.ts
@@ -1661,7 +1661,7 @@ export interface DataFrame
    */
   withColumn(column: Series | Expr): DataFrame;
   withColumn(column: Series | Expr): DataFrame;
-  withColumns(column: Series | Expr, ...columns: Expr[] | Series[]): DataFrame;
+  withColumns(...columns: (Expr | Series)[]): DataFrame;
   /**
    * Return a new DataFrame with the column renamed.
    * @param existingName
@@ -2301,9 +2301,7 @@ export const _DataFrame = (_df: any): DataFrame => {
         return this.withColumns(column);
       }
     },
-    withColumns(column, ...columns: Expr[] | Series[]) {
-      columns.unshift(column as any);
-
+    withColumns(...columns: (Expr | Series)[]) {
       if (isSeriesArray(columns)) {
         return columns.reduce(
           (acc, curr) => acc.withColumn(curr),

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -12,6 +12,7 @@ import {
 import { _LazyGroupBy, LazyGroupBy } from "./groupby";
 import { Deserialize, GroupByOps, Serialize } from "../shared_traits";
 import { LazyOptions, LazyJoinOptions } from "../types";
+import { Series } from "@polars/series";
 
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
@@ -446,8 +447,8 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    * @param exprs - List of Expressions that evaluate to columns.
    *
    */
-  withColumns(exprs: Expr[]): LazyDataFrame;
-  withColumns(expr: Expr, ...exprs: Expr[]): LazyDataFrame;
+  withColumns(exprs: (Expr | Series)[]): LazyDataFrame;
+  withColumns(...exprs: (Expr | Series)[]): LazyDataFrame;
   withColumnRenamed(existing: string, replacement: string): LazyDataFrame;
   /**
    * Add a column at index 0 that counts the rows.

--- a/polars/utils.ts
+++ b/polars/utils.ts
@@ -51,7 +51,7 @@ export const range = (start: number, end: number) => {
 export const isDataFrameArray = (ty: any): ty is DataFrame[] =>
   Array.isArray(ty) && DataFrame.isDataFrame(ty[0]);
 export const isSeriesArray = <T>(ty: any): ty is Series[] =>
-  Array.isArray(ty) && Series.isSeries(ty[0]);
+  Array.isArray(ty) && ty.every(Series.isSeries);
 export const isExprArray = (ty: any): ty is Expr[] =>
   Array.isArray(ty) && Expr.isExpr(ty[0]);
 export const isIterator = <T>(ty: any): ty is Iterable<T> =>


### PR DESCRIPTION
All tests are passing.

Also tested it on my own, and it worked flawlessly:

```js
	const df = pl.DataFrame(
		{
			"foo": [1, 2, 5],
			"bar": [6, 7, 8],
			"ham": ["a", "b", "c"]
		}
	).lazy()

	console.log(df.withColumns(
		pl.Series('qux', [1, 2, 3]),
		pl.col('foo').alias('foo2'),
		pl.col('bar').alias('bar2'),
	).collect())
```

```js
	const df = pl.DataFrame(
		{
			"foo": [1, 2, 5],
			"bar": [6, 7, 8],
			"ham": ["a", "b", "c"]
		}
	)

	console.log(await df.withColumns(
		pl.Series('qux', [1, 2, 3]),
		pl.col('foo').alias('foo2'),
		pl.col('bar').alias('bar2'),
	))
```

```
shape: (3, 6)
┌─────┬─────┬─────┬─────┬──────┬──────┐
│ foo ┆ bar ┆ ham ┆ qux ┆ foo2 ┆ bar2 │
│ --- ┆ --- ┆ --- ┆ --- ┆ ---  ┆ ---  │
│ f64 ┆ f64 ┆ str ┆ f64 ┆ f64  ┆ f64  │
╞═════╪═════╪═════╪═════╪══════╪══════╡
│ 1.0 ┆ 6.0 ┆ a   ┆ 1.0 ┆ 1.0  ┆ 6.0  │
├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ 2.0 ┆ 7.0 ┆ b   ┆ 2.0 ┆ 2.0  ┆ 7.0  │
├╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ 5.0 ┆ 8.0 ┆ c   ┆ 3.0 ┆ 5.0  ┆ 8.0  │
└─────┴─────┴─────┴─────┴──────┴──────┘
```