### PR TITLE
Fix TS2556 for select when spreading an array

### DIFF
--- a/__tests__/dataframe.test.ts
+++ b/__tests__/dataframe.test.ts
@@ -751,13 +751,14 @@ describe("dataframe", () => {
     expect(fn).toThrow(TypeError);
   });
   test("select:strings", () => {
+    const columns = ["ham", "foo"]
     const actual = pl
       .DataFrame({
         foo: [1, 2, 3, 1],
         bar: [6, 7, 8, 1],
         ham: ["a", "b", "c", null],
       })
-      .select("ham", "foo");
+      .select(...columns);
     const foo = pl.Series("foo", [1, 2, 3, 1]);
     const ham = pl.Series("ham", ["a", "b", "c", null]);
     expect(actual.width).toStrictEqual(2);

--- a/__tests__/lazyframe.test.ts
+++ b/__tests__/lazyframe.test.ts
@@ -797,6 +797,7 @@ describe("lazyframe", () => {
     expect(actual.getColumn("ham")).toSeriesEqual(ham);
   });
   test("select:strings", () => {
+    const columns = ["ham", "foo"]
     const actual = pl
       .DataFrame({
         foo: [1, 2, 3, 1],
@@ -804,7 +805,7 @@ describe("lazyframe", () => {
         ham: ["a", "b", "c", null],
       })
       .lazy()
-      .select("ham", "foo")
+      .select(...columns)
       .collectSync();
     const foo = pl.Series("foo", [1, 2, 3, 1]);
     const ham = pl.Series("ham", ["a", "b", "c", null]);

--- a/polars/dataframe.ts
+++ b/polars/dataframe.ts
@@ -1190,7 +1190,7 @@ export interface DataFrame
    * └─────┘
    * ```
    */
-  select(column: ExprOrString, ...columns: ExprOrString[]): DataFrame;
+  select(...columns: ExprOrString[]): DataFrame;
   /**
    * Shift the values by a given period and fill the parts that will be empty due to this operation
    * with `Nones`.

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -368,7 +368,7 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    */
   select(column: ExprOrString): LazyDataFrame;
   select(columns: ExprOrString[]): LazyDataFrame;
-  select(column: ExprOrString, ...columns: ExprOrString[]): LazyDataFrame;
+  select(...columns: ExprOrString[]): LazyDataFrame;
   /**
    * @see {@link DataFrame.shift}
    */


### PR DESCRIPTION
```
const foo = ["a", "b"]
df.select(...foo)
```

failed with TS2556 "A spread argument must either have a tuple type or be passed to a rest parameter"

I think only `df.select('c', ...foo)` would have worked with the old function headers

There are other cases where this probably has to be changed: `drop`, `explode`, `agg`, etc.

If I change all of those to use one single spread parameter, will just running the tests be reliable enough to verify if everything still works fine? Or should every occurence be also tested manually?