### PR TITLE
feat: 🎸 support dtypes option for read_csv function

### DIFF
--- a/__tests__/io.test.ts
+++ b/__tests__/io.test.ts
@@ -76,6 +76,12 @@ describe("read:csv", () => {
     const maxRowCount = df.getColumn("rc").max();
     expect(expectedMaxRowCount).toStrictEqual(maxRowCount);
   });
+  test("csv with dtypes", () => {
+    const df = pl.readCSV(csvpath, { dtypes: { calories: pl.Utf8 }});
+    expect(df.dtypes[1].equals(pl.Utf8)).toBeTruthy();
+    const df2 = pl.readCSV(csvpath);
+    expect(df2.dtypes[1].equals(pl.Int64)).toBeTruthy();
+  });
   it.todo("can read from a stream");
 });
 

--- a/polars/io.ts
+++ b/polars/io.ts
@@ -20,7 +20,7 @@ export interface ReadCsvOptions {
   rechunk: boolean;
   encoding: "utf8" | "utf8-lossy";
   numThreads: number;
-  dtype: any;
+  dtypes: Record<string, DataType>;
   lowMemory: boolean;
   commentChar: string;
   quotChar: string;


### PR DESCRIPTION
Old vertion provide dtype property in ReadCsvOptions（polars/io.ts）, but is not implement in src/dataframe.rs, so it implement dtypes option for read_csv function and due to it is a collection of column type defination, so change name to dtypes