### PR TITLE
fix: 🐛 dtypes should take effect on readCSV for buffer input

### DIFF
--- a/__tests__/io.test.ts
+++ b/__tests__/io.test.ts
@@ -76,12 +76,21 @@ describe("read:csv", () => {
     const maxRowCount = df.getColumn("rc").max();
     expect(expectedMaxRowCount).toStrictEqual(maxRowCount);
   });
-  test("csv with dtypes", () => {
+  test("csv files with dtypes", () => {
     const df = pl.readCSV(csvpath, { dtypes: { calories: pl.Utf8 }});
     expect(df.dtypes[1].equals(pl.Utf8)).toBeTruthy();
     const df2 = pl.readCSV(csvpath);
     expect(df2.dtypes[1].equals(pl.Int64)).toBeTruthy();
   });
+  test("csv buffer with dtypes", () => {
+    const csv = `a,b,c
+1,2,x
+4,5,y`
+    const df = pl.readCSV(csv);
+    expect(df.dtypes[0].equals(pl.Int64)).toBeTruthy();
+    const df2 = pl.readCSV(csv, { dtypes: { a: pl.Utf8 }});
+    expect(df2.dtypes[0].equals(pl.Utf8)).toBeTruthy();
+  })
   it.todo("can read from a stream");
 });
 

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -146,6 +146,7 @@ pub fn read_csv(
                 .with_encoding(encoding)
                 .with_columns(options.columns)
                 .with_n_threads(n_threads)
+                .with_dtypes(dtypes.as_ref())
                 .low_memory(options.low_memory)
                 .with_comment_char(comment_char)
                 .with_null_values(null_values)


### PR DESCRIPTION
As pr #64, support dtypes option for readCSV but not implement for read_csv when first param is buffer, so fix it.