### PR TITLE
fix: from_rows

### DIFF
--- a/__tests__/dataframe.test.ts
+++ b/__tests__/dataframe.test.ts
@@ -2292,4 +2292,14 @@ describe("additional", () => {
 
     expect(dfs).toEqual(expected);
   });
+  test("df from rows with schema", () => {
+    const rows = [{ a: 1, b: 2, c: null }];
+
+    const df = pl.DataFrame(rows, {
+      schema: { a: pl.Int32, b: pl.Int32, c: pl.Utf8 },
+      orient: "row",
+    });
+    const actual = df.toRecords();
+    expect(actual).toEqual(rows);
+  });
 });

--- a/polars/internals/construction.ts
+++ b/polars/internals/construction.ts
@@ -181,6 +181,8 @@ export function arrayToJsSeries(
 export function arrayToJsDataFrame(data: any[], options?): any {
   const columns = options?.columns;
   let orient = options?.orient;
+  const schema = options?.schema;
+  const inferSchemaLength = options?.inferSchemaLength;
 
   let dataSeries: any[];
 
@@ -196,7 +198,7 @@ export function arrayToJsDataFrame(data: any[], options?): any {
       dataSeries.push(series._s);
     });
   } else if (data[0].constructor.name === "Object") {
-    const df = pli.fromRows(data, options);
+    const df = pli.fromRows(data, schema, inferSchemaLength);
 
     if (columns) {
       df.columns = columns;


### PR DESCRIPTION
closes #20

note: the explicit schema is required if you want to retain the null values.

```js
// this will drop the null column if all values of "c" are null
> pl.DataFrame([{a:1, b:2, c:null}])

shape: (1, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ f64 ┆ f64 │
╞═════╪═════╡
│ 1.0 ┆ 2.0 │
└─────┴─────┘
```

```js
// this will strictly use the schema provided.
> pl.DataFrame([{a:1, b:2, c:null}], {
  schema: { a: pl.Int32, b: pl.Int32, c: pl.Utf8 },
  orient: "row",
});

shape: (1, 3)
┌─────┬─────┬──────┐
│ a   ┆ b   ┆ c    │
│ --- ┆ --- ┆ ---  │
│ i32 ┆ i32 ┆ str  │
╞═════╪═════╪══════╡
│ 1   ┆ 2   ┆ null │
└─────┴─────┴──────┘
```