### PR TITLE
create built in way to visualize dataframe in Jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,43 @@ Releases happen quite often (weekly / every few days) at the moment, so updating
 - Node version `>=18`
 - Rust version `>=1.59` - *Only needed for development*
 
+
+## Deno
+
+In Deno modules you can import polars straight from `npm`:
+
+```typescript
+import pl from "npm:nodejs-polars";
+```
+
+With Deno 1.37, you can use the `display` function to display a `DataFrame` in the notebook:
+
+```typescript
+import pl from "npm:nodejs-polars";
+import { display } from "https://deno.land/x/display@v1.1.1/mod.ts";
+
+let response = await fetch(
+  "https://cdn.jsdelivr.net/npm/world-atlas@1/world/110m.tsv",
+);
+let data = await response.text();
+let df = pl.readCSV(data, { sep: "\t" });
+await display(df)
+```
+
+With Deno 1.38, you only have to make the dataframe be the last expression in the cell:
+
+```typescript
+import pl from "npm:nodejs-polars";
+let response = await fetch(
+  "https://cdn.jsdelivr.net/npm/world-atlas@1/world/110m.tsv",
+);
+let data = await response.text();
+let df = pl.readCSV(data, { sep: "\t" });
+df
+```
+
+<img width="510" alt="image" src="https://github.com/pola-rs/nodejs-polars/assets/836375/90cf7bf4-7478-4919-b297-f8eb6a16196f">
+
 ___
 
 ## Documentation

--- a/__tests__/dataframe.test.ts
+++ b/__tests__/dataframe.test.ts
@@ -2250,6 +2250,33 @@ describe("meta", () => {
   });
 });
 
+test("Jupyter.display", () => {
+  const df = pl.DataFrame({
+    os: ["apple", "linux"],
+    version: [10.12, 18.04],
+  });
+  expect(Symbol.for("Jupyter.display") in df).toBe(true);
+
+  const actual = df[Symbol.for("Jupyter.display")]();
+
+  expect(actual).toBeInstanceOf(Object);
+
+  const dataResource = actual["application/vnd.dataresource+json"];
+  expect(dataResource).toBeInstanceOf(Object);
+  expect(dataResource).toHaveProperty("schema");
+  expect(dataResource).toHaveProperty("data");
+  expect(dataResource).toHaveProperty("data", [
+    { os: "apple", version: 10.12 },
+    { os: "linux", version: 18.04 },
+  ]);
+
+  const html = actual["text/html"];
+  expect(html).toContain("apple");
+  expect(html).toContain("linux");
+  expect(html).toContain("10.12");
+  expect(html).toContain("18.04");
+});
+
 describe("additional", () => {
   test("partitionBy", () => {
     const df = pl.DataFrame({

--- a/polars/html.ts
+++ b/polars/html.ts
@@ -1,0 +1,18 @@
+const rawToEntityEntries = [
+  ["&", "&amp;"],
+  ["<", "&lt;"],
+  [">", "&gt;"],
+  ['"', "&quot;"],
+  ["'", "&#39;"],
+] as const;
+
+const rawToEntity = new Map<string, string>(rawToEntityEntries);
+
+const rawRe = new RegExp(`[${[...rawToEntity.keys()].join("")}]`, "g");
+
+/**
+ * Escapes text for safe interpolation into HTML text content and quoted attributes
+ */
+export function escapeHTML(str: string) {
+  return str.replaceAll(rawRe, (m) => rawToEntity.get(m) ?? m);
+}


### PR DESCRIPTION
Hi! 👋🏻

This introduces a basic way to display Polars DataFrames from a deno kernel in a Jupyter Notebook.

<img width="510" alt="image" src="https://github.com/pola-rs/nodejs-polars/assets/836375/90cf7bf4-7478-4919-b297-f8eb6a16196f">

While I've [baked it into `display.js`](https://github.com/rgbkrk/display.js/blob/main/test-notebooks/polars-df.ipynb), which is on its way to be part of `Deno` itself (https://github.com/denoland/deno/pull/20819), I'd love to get a solid implementation inside of `nodejs-polars`. There are two mediatypes exported here via the [Rich Content Output Symbol, `Symbol.for("Jupyter.display")`](https://docs.deno.com/runtime/manual/tools/jupyter#rich-content-output)

* `text/html` - a standard static table we're all pretty used to
* `application/vnd.dataresource+json` - Row oriented JSON for frontends to implement scrollable grids for a table (and additional data visualization).

Here's an example of what's possible with the data resource media type:

<img width="1307" alt="image" src="https://github.com/pola-rs/nodejs-polars/assets/836375/2d2d7a37-2ab6-4266-a1ed-ce06303be729">

Blog post featuring `nodejs-polars`: https://blog.jupyter.org/bringing-modern-javascript-to-the-jupyter-notebook-fc998095081e

Once this is in I'll update the blog post screenshots to use the implementation that relies on `nodejs-polars`.

## Background on the Data Resource Schema

Using the schema from https://specs.frictionlessdata.io/schemas/tabular-data-resource.json, we can emit a format that frontends can use for much richer tables.

As an example, in `pandas` you enable it with:

```python
pd.set_option("display.html.table_schema", True)
```

and then just type `df` in cells. Here's some more sample (python) code for looking at this format

```python
import pandas as pd

df = pd.read_csv(
    "https://raw.githubusercontent.com/allisonhorst/palmerpenguins/main/inst/extdata/penguins.csv"
)
# Enable { schema, data } output as JSON
pd.set_option("display.html.table_schema", True)

# Now to demonstrate what's inside
import json

ip = get_ipython()

# Enable { schema, data } output as JSON
pd.set_option("display.html.table_schema", True)
data, metadata = ip.display_formatter.format(df.head(5))

data_resource = data['application/vnd.dataresource+json']

print(json.dumps(data_resource, indent=2))
```

```json
{
  "schema": {
    "fields": [
      {
        "name": "index",
        "type": "integer"
      },
      {
        "name": "species",
        "type": "string"
      },
      {
        "name": "island",
        "type": "string"
      },
      {
        "name": "bill_length_mm",
        "type": "number"
      },
      {
        "name": "bill_depth_mm",
        "type": "number"
      },
      {
        "name": "flipper_length_mm",
        "type": "number"
      },
      {
        "name": "body_mass_g",
        "type": "number"
      },
      {
        "name": "sex",
        "type": "string"
      },
      {
        "name": "year",
        "type": "integer"
      }
    ],
    "primaryKey": [
      "index"
    ],
    "pandas_version": "1.4.0"
  },
  "data": [
    {
      "index": 0,
      "species": "Adelie",
      "island": "Torgersen",
      "bill_length_mm": 39.1,
      "bill_depth_mm": 18.7,
      "flipper_length_mm": 181.0,
      "body_mass_g": 3750.0,
      "sex": "male",
      "year": 2007
    },
    {
      "index": 1,
      "species": "Adelie",
      "island": "Torgersen",
      "bill_length_mm": 39.5,
      "bill_depth_mm": 17.4,
      "flipper_length_mm": 186.0,
      "body_mass_g": 3800.0,
      "sex": "female",
      "year": 2007
    },
    {
      "index": 2,
      "species": "Adelie",
      "island": "Torgersen",
      "bill_length_mm": 40.3,
      "bill_depth_mm": 18.0,
      "flipper_length_mm": 195.0,
      "body_mass_g": 3250.0,
      "sex": "female",
      "year": 2007
    },
    {
      "index": 3,
      "species": "Adelie",
      "island": "Torgersen",
      "bill_length_mm": null,
      "bill_depth_mm": null,
      "flipper_length_mm": null,
      "body_mass_g": null,
      "sex": null,
      "year": 2007
    },
    {
      "index": 4,
      "species": "Adelie",
      "island": "Torgersen",
      "bill_length_mm": 36.7,
      "bill_depth_mm": 19.3,
      "flipper_length_mm": 193.0,
      "body_mass_g": 3450.0,
      "sex": "female",
      "year": 2007
    }
  ]
}
```