### PR TITLE
Fixing unique expr with maintainOrder option

### DIFF
--- a/__tests__/expr.test.ts
+++ b/__tests__/expr.test.ts
@@ -879,13 +879,16 @@ describe("expr", () => {
     expect(actual).toFrameEqual(expected);
   });
   test("unique", () => {
-    const df = pl.DataFrame({ a: [1, 1, 2, 2, 3, 3, 8, null, 1] });
-    const expected = pl.DataFrame({
-      uniques: [1, 2, 3, 8, null],
-    });
-    const actual = df.select(
+    const df = pl.DataFrame({ a: [2, 3, 1, 2, 1, 3, 8, null, 1] });
+    let expected = pl.DataFrame({ uniques: [1, 2, 3, 8, null] });
+    let actual = df.select(
       col("a").unique().sort({ nullsLast: true }).as("uniques"),
     );
+    expect(actual).toFrameEqual(expected);
+    expected = pl.DataFrame({ uniques: [2, 3, 1, 8, null] });
+    actual = df.select(col("a").unique(true).as("uniques"));
+    expect(actual).toFrameEqual(expected);
+    actual = df.select(col("a").unique({ maintainOrder: true }).as("uniques"));
     expect(actual).toFrameEqual(expected);
   });
   test("upperBound", () => {

--- a/polars/lazy/expr/index.ts
+++ b/polars/lazy/expr/index.ts
@@ -567,7 +567,8 @@ export interface Expr
    * Get the unique values of this expression;
    * @param maintainOrder Maintain order of data. This requires more work.
    */
-  unique(maintainOrder?: boolean | { maintainOrder: boolean }): Expr;
+  unique(opt: { maintainOrder: boolean }): Expr;
+  unique(maintainOrder?: boolean): Expr;
   /** Returns a unit Series with the highest value possible for the dtype of this expression. */
   upperBound(): Expr;
   /** Get variance. */
@@ -1195,8 +1196,8 @@ export const _Expr = (_expr: any): Expr => {
       return _Expr(_expr.takeEvery(n));
     },
     unique(opt?) {
-      if (opt) {
-        return wrap("unique_stable");
+      if (opt || opt?.maintainOrder) {
+        return wrap("uniqueStable");
       }
 
       return wrap("unique");


### PR DESCRIPTION
unique expr with maintainOrder was calling an unknown function. This PR fixes unique expr with maintainOrder option.