### PR TITLE
fix(partitionBy): set default value for `includeKey`

### DIFF
--- a/polars/dataframe.ts
+++ b/polars/dataframe.ts
@@ -2061,7 +2061,7 @@ export const _DataFrame = (_df: any): DataFrame => {
     nullCount() {
       return wrap("nullCount");
     },
-    partitionBy(by, strict = false, includeKey?: boolean, mapFn = (df) => df) {
+    partitionBy(by, strict = false, includeKey = true, mapFn = (df) => df) {
       by = Array.isArray(by) ? by : [by];
       return _df
         .partitionBy(by, strict, includeKey)


### PR DESCRIPTION
This patch fixes an issue with `partitionBy` when you call it without any optional arguments.

Since `includeKey` has no default value, calling `df.partitionBy('some_column')` results in the following error:

```
Error: Failed to convert napi value into rust type `bool`
    at Proxy.partitionBy (node_modules/nodejs-polars/bin/dataframe.js:309:18)
```

This is caused by the fact that the value being passed for `includeKey` is `undefined`.

This patch reflects the default in the Rust version, which is `includeKey = true`.