### PR TITLE
Replacing groupBy count with len

### DIFF
--- a/__tests__/groupby.test.ts
+++ b/__tests__/groupby.test.ts
@@ -46,14 +46,15 @@ describe("groupby", () => {
     });
     expect(actual).toFrameEqual(expected);
   });
-
-  test("count", () => {
-    const actual = df.groupBy("name").count().sort("name");
+  test("len", () => {
+    let actual = df.groupBy("name").len().sort("name");
     const expected = pl.DataFrame({
       name: ["a", "b", "c"],
-      foo_count: [2, 2, 1],
-      bar_count: [2, 2, 1],
+      name_count: [2, 2, 1],
     });
+    expect(actual).toFrameEqual(expected);
+    // Test for single column DF
+    actual = df.select("name").groupBy("name").len().sort("name");
     expect(actual).toFrameEqual(expected);
   });
   test("first", () => {

--- a/polars/groupby.ts
+++ b/polars/groupby.ts
@@ -46,8 +46,13 @@ export interface GroupBy {
   agg(columns: Record<string, keyof Expr | (keyof Expr)[]>): DataFrame;
   /**
    * Count the number of values in each group.
+   * @deprecated @since 0.10.0 @use {@link len}
    */
   count(): DataFrame;
+  /**
+   * Return the number of rows in each group.
+   */
+  len(): DataFrame;
   /**
    * Aggregate the first values in the group.
    */
@@ -208,7 +213,10 @@ export function _GroupBy(df: any, by: string[], maintainOrder = false) {
     pivot,
     aggList: () => agg(exclude(by as any)),
     count() {
-      return _DataFrame(df.groupby([by].flat(), null, "count"));
+      return _DataFrame(df.groupby([by].flat(), by, "count"));
+    },
+    len() {
+      return _DataFrame(df.groupby([by].flat(), by, "count"));
     },
     first: () => agg(exclude(by as any).first()),
     groups() {


### PR DESCRIPTION
1. Replacing groupBy count with len
2. Changing groupBy len/count logic to match Python version
3. Closing #191 