### PR TITLE
Check nullCount in Series.toTypedArray

### DIFF
--- a/__tests__/series.test.ts
+++ b/__tests__/series.test.ts
@@ -656,6 +656,12 @@ describe("series", () => {
     const actual = s.round({ decimals: 2 });
     expect(actual).toSeriesEqual(expected);
   });
+  test("toTypedArray handles nulls", () => {
+    const s = pl.Series('ints and nulls', [1, 2, 3, null, 5], pl.UInt8);
+    expect(() => s.toTypedArray()).toThrow();
+    expect(() => s.dropNulls().toTypedArray()).not.toThrow();
+    expect(s.dropNulls().toTypedArray()).toStrictEqual(new Uint8Array([1, 2, 3, 5]));
+  })
 });
 describe("comparators & math", () => {
   test("add/plus", () => {

--- a/__tests__/series.test.ts
+++ b/__tests__/series.test.ts
@@ -657,11 +657,13 @@ describe("series", () => {
     expect(actual).toSeriesEqual(expected);
   });
   test("toTypedArray handles nulls", () => {
-    const s = pl.Series('ints and nulls', [1, 2, 3, null, 5], pl.UInt8);
+    const s = pl.Series("ints and nulls", [1, 2, 3, null, 5], pl.UInt8);
     expect(() => s.toTypedArray()).toThrow();
     expect(() => s.dropNulls().toTypedArray()).not.toThrow();
-    expect(s.dropNulls().toTypedArray()).toStrictEqual(new Uint8Array([1, 2, 3, 5]));
-  })
+    expect(s.dropNulls().toTypedArray()).toStrictEqual(
+      new Uint8Array([1, 2, 3, 5]),
+    );
+  });
 });
 describe("comparators & math", () => {
   test("add/plus", () => {

--- a/polars/series/index.ts
+++ b/polars/series/index.ts
@@ -1710,7 +1710,7 @@ export function _Series(_s: any): Series {
       return _s.toArray();
     },
     toTypedArray() {
-      if (!this.hasValidity()) {
+      if (!this.hasValidity() || this.nullCount() === 0) {
         return _s.toTypedArray();
       }
       throw new Error("data contains nulls, unable to convert to TypedArray");


### PR DESCRIPTION
Don’t rely solely on `has_validity` to determine whether a series contains nulls

From the [Python documentation](https://docs.pola.rs/py-polars/html/reference/series/api/polars.Series.has_validity.html#polars.Series.has_validity) for `has_validity` (emphasis mine):
> While the absence of a validity bitmask guarantees that a Series does not have `null` values, the converse is not true, eg: **the presence of a bitmask does not mean that there are null values**, as every value of the bitmask could be `false`.
> 
> To confirm that a column has null values use `null_count()`.

This PR modifies the logic for `Series.toTypedArray` (in line with the note quoted above) to check `nullCount()` if the Series `hasValidity()`, rather than relying on the `hasValidity()` check alone.

Closes #206 