### PR TITLE
fix: fixing incorrect example

### DIFF
--- a/polars/dataframe.ts
+++ b/polars/dataframe.ts
@@ -1034,7 +1034,7 @@ export interface DataFrame
    *   ...         "baz": [1, 2, 3, 4, 5, 6],
    *   ...     }
    *   ... );
-   *   > df.pivot(values:"baz", {index:"foo", columns:"bar"});
+   *   > df.pivot("baz", {index:"foo", columns:"bar"});
    *   shape: (2, 4)
    *   ┌─────┬─────┬─────┬─────┐
    *   │ foo ┆ A   ┆ B   ┆ C   │


### PR DESCRIPTION
"value:" is incorrect in the context of pivot, removed