### PR TITLE
feat: Add concatenation of LazyDataFrames

### DIFF
--- a/__tests__/functions.test.ts
+++ b/__tests__/functions.test.ts
@@ -18,6 +18,72 @@ describe("concat", () => {
     expect(actual).toFrameEqual(expected);
   });
 
+  it("can concat multiple lazy dataframes vertically", () => {
+    const df1 = pl
+      .DataFrame({
+        a: [1, 2, 3],
+        b: ["a", "b", "c"],
+      })
+      .lazy();
+    const df2 = pl
+      .DataFrame({
+        a: [4, 5, 6],
+        b: ["d", "e", "f"],
+      })
+      .lazy();
+    const actual = pl.concat([df1, df2]).collectSync();
+    const expected = pl.DataFrame({
+      a: [1, 2, 3, 4, 5, 6],
+      b: ["a", "b", "c", "d", "e", "f"],
+    });
+    expect(actual).toFrameEqual(expected);
+  });
+
+  it("can concat multiple lazy dataframes horizontally", () => {
+    const df1 = pl
+      .DataFrame({
+        a: [1, 2, 3],
+        b: ["a", "b", "c"],
+      })
+      .lazy();
+    const df2 = pl
+      .DataFrame({
+        c: [4, 5, 6],
+        d: ["d", "e", "f"],
+      })
+      .lazy();
+    const actual = pl.concat([df1, df2], { how: "horizontal" }).collectSync();
+    const expected = pl.DataFrame({
+      a: [1, 2, 3],
+      b: ["a", "b", "c"],
+      c: [4, 5, 6],
+      d: ["d", "e", "f"],
+    });
+    expect(actual).toFrameEqual(expected);
+  });
+
+  it("can concat multiple lazy dataframes diagonally", () => {
+    const df1 = pl
+      .DataFrame({
+        a: [1],
+        b: [3],
+      })
+      .lazy();
+    const df2 = pl
+      .DataFrame({
+        a: [2],
+        d: [4],
+      })
+      .lazy();
+    const actual = pl.concat([df1, df2], { how: "diagonal" }).collectSync();
+    const expected = pl.DataFrame({
+      a: [1, 2],
+      b: [3, null],
+      d: [null, 4],
+    });
+    expect(actual).toFrameEqual(expected);
+  });
+
   it("can concat multiple series vertically", () => {
     const s1 = pl.Series("a", [1, 2, 3]);
     const s2 = pl.Series("a", [4, 5, 6]);

--- a/polars/functions.ts
+++ b/polars/functions.ts
@@ -93,8 +93,11 @@ export function concat(
   items: Array<LazyDataFrame>,
   options?: ConcatOptions,
 ): LazyDataFrame;
-export function concat(items, options?: ConcatOptions) {
-  const { rechunk = false, how = "vertical", parallel = true } = options || {};
+export function concat(
+  items,
+  options: ConcatOptions = { rechunk: true, how: "vertical" },
+) {
+  const { rechunk, how } = options;
 
   if (!items.length) {
     throw new RangeError("cannot concat empty list");
@@ -123,6 +126,7 @@ export function concat(items, options?: ConcatOptions) {
       pli.concatLf(
         items.map((i: any) => i.inner()),
         how,
+        rechunk,
       ),
     );
 

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -167,6 +167,7 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    * The `fetch` operation will truly load the first `n`rows lazily.
    */
   head(length?: number): LazyDataFrame;
+  inner(): any;
   /**
    *  __SQL like joins.__
    * @param df - DataFrame to join with.
@@ -780,6 +781,9 @@ export const _LazyDataFrame = (_ldf: any): LazyDataFrame => {
     },
     head(len = 5) {
       return _LazyDataFrame(_ldf.slice(0, len));
+    },
+    inner() {
+      return _ldf;
     },
     join(df, options) {
       options = {

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -28,6 +28,7 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
   /** @ignore */
   _ldf: any;
   [inspect](): string;
+  [Symbol.toStringTag]: string;
   get columns(): string[];
   /**
    * Cache the result once the execution of the physical plan hits this node.
@@ -600,6 +601,9 @@ export const _LazyDataFrame = (_ldf: any): LazyDataFrame => {
     _ldf,
     [inspect]() {
       return _ldf.describeOptimizedPlan();
+    },
+    get [Symbol.toStringTag]() {
+      return "LazyDataFrame";
     },
 
     get columns() {

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -28,6 +28,7 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
   /** @ignore */
   _ldf: any;
   [inspect](): string;
+  [Symbol.toStringTag]: string;
   get columns(): string[];
   /**
    * Cache the result once the execution of the physical plan hits this node.

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -1021,7 +1021,11 @@ export const _LazyDataFrame = (_ldf: any): LazyDataFrame => {
 
 export interface LazyDataFrameConstructor extends Deserialize<LazyDataFrame> {
   fromExternal(external: any): LazyDataFrame;
+  isLazyDataFrame(arg: any): arg is LazyDataFrame;
 }
+
+const isLazyDataFrame = (anyVal: any): anyVal is LazyDataFrame =>
+  anyVal?.[Symbol.toStringTag] === "LazyDataFrame";
 
 /** @ignore */
 export const LazyDataFrame: LazyDataFrameConstructor = Object.assign(
@@ -1032,5 +1036,6 @@ export const LazyDataFrame: LazyDataFrameConstructor = Object.assign(
     fromExternal(external) {
       return _LazyDataFrame(pli.JsLazyFrame.cloneExternal(external));
     },
+    isLazyDataFrame,
   },
 );

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -28,7 +28,6 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
   /** @ignore */
   _ldf: any;
   [inspect](): string;
-  [Symbol.toStringTag]: string;
   get columns(): string[];
   /**
    * Cache the result once the execution of the physical plan hits this node.

--- a/polars/utils.ts
+++ b/polars/utils.ts
@@ -1,6 +1,7 @@
 import { Expr, exprToLitOrExpr } from "./lazy/expr";
 import { Series } from "./series";
 import { DataFrame } from "./dataframe";
+import { LazyDataFrame } from "./lazy/dataframe";
 import path from "path";
 import { isExternal, isRegExp } from "util/types";
 /** @ignore */
@@ -52,6 +53,8 @@ export const range = (start: number, end: number) => {
 
 export const isDataFrameArray = (ty: any): ty is DataFrame[] =>
   Array.isArray(ty) && DataFrame.isDataFrame(ty[0]);
+export const isLazyDataFrameArray = (ty: any): ty is LazyDataFrame[] =>
+  Array.isArray(ty) && LazyDataFrame.isLazyDataFrame(ty[0]);
 export const isSeriesArray = <T>(ty: any): ty is Series[] =>
   Array.isArray(ty) && ty.every(Series.isSeries);
 export const isExprArray = (ty: any): ty is Expr[] =>

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -33,6 +33,8 @@ pub fn concat_lf(
         ..Default::default()
     };
     let ldf = match how.as_deref() {
+        // Default to vertical
+        None => concat(&ldfs, union_args),
         Some("vertical") => concat(&ldfs, union_args),
         Some("horizontal") => concat_lf_horizontal(&ldfs, union_args),
         Some("diagonal") => concat_lf_diagonal(
@@ -48,7 +50,6 @@ pub fn concat_lf(
                 unknown
             )))
         }
-        None => concat(&ldfs, union_args),
     }
     .map_err(crate::error::JsPolarsErr::from)?;
 


### PR DESCRIPTION
Resolves https://github.com/pola-rs/nodejs-polars/issues/232

Exposes the underlying lazy-compatible `concat`, `concat_lf_horizontal`, and `concat_lf_diagonal` functions in native.

Tried to keep things reasonably inline with existing code. Added tests that verify the behavior 👍 