### PR TITLE
fix: update pivot expr on to first param

### DIFF
--- a/__tests__/dataframe.test.ts
+++ b/__tests__/dataframe.test.ts
@@ -1354,6 +1354,49 @@ describe("dataframe", () => {
       "e|b": [null, "y"],
     });
     expect(actual).toFrameEqual(expected, true);
+
+    df = pl.DataFrame({
+      foo: ["A", "A", "B", "B", "C"],
+      N: [1, 2, 2, 4, 2],
+      bar: ["k", "l", "m", "n", "o"],
+    });
+    actual = df.pivot(["N"], {
+      index: "foo",
+      on: "bar",
+      aggregateFunc: "first",
+    });
+    expected = pl.DataFrame({
+      foo: ["A", "B", "C"],
+      k: [1, null, null],
+      l: [2, null, null],
+      m: [null, 2, null],
+      n: [null, 4, null],
+      o: [null, null, 2],
+    });
+    expect(actual).toFrameEqual(expected, true);
+
+    df = pl.DataFrame({
+      ix: [1, 1, 2, 2, 1, 2],
+      col: ["a", "a", "a", "a", "b", "b"],
+      foo: [0, 1, 2, 2, 7, 1],
+      bar: [0, 2, 0, 0, 9, 4],
+    });
+
+    actual = df.pivot(["foo", "bar"], {
+      index: "ix",
+      on: "col",
+      aggregateFunc: "sum",
+      separator: "/",
+    });
+
+    expected = pl.DataFrame({
+      ix: [1, 2],
+      "foo/a": [1, 4],
+      "foo/b": [7, 1],
+      "bar/a": [2, 0],
+      "bar/b": [9, 4],
+    });
+    expect(actual).toFrameEqual(expected, true);
   });
 });
 describe("join", () => {

--- a/polars/dataframe.ts
+++ b/polars/dataframe.ts
@@ -2237,8 +2237,8 @@ export const _DataFrame = (_df: any): DataFrame => {
       return _DataFrame(
         _df.pivotExpr(
           values,
-          index,
           on,
+          index,
           fn,
           maintainOrder,
           sortColumns,

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -895,8 +895,8 @@ impl JsDataFrame {
     pub fn pivot_expr(
         &self,
         values: Vec<String>,
+        on: Vec<String>,
         index: Vec<String>,
-        columns: Vec<String>,
         aggregate_expr: Option<Wrap<polars::prelude::Expr>>,
         maintain_order: bool,
         sort_columns: bool,
@@ -908,8 +908,8 @@ impl JsDataFrame {
         };
         fun(
             &self.df,
-            index,
-            Some(columns),
+            on,
+            Some(index),
             Some(values),
             sort_columns,
             aggregate_expr.map(|e| e.0 as Expr),


### PR DESCRIPTION
The pivot function now has `on` as the first param instead of `index`, as noted in the [python 1.0 upgrade documentation](https://docs.pola.rs/releases/upgrade/1/#update-resulting-column-names-in-pivot-when-pivoting-by-multiple-values):
> columns has been renamed to on, and is now the first positional argument.
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/1110a76d-2212-4fd0-9508-ce3bd3b619ba">

Added some test coverage from examples in docs to capture this. Existing test coverage was using the same column as `index` and `on`, resulting in this not being caught.