### PR TITLE
fix: fix broken path to datatypes causing typescript compilation to fail

### DIFF
--- a/polars/series/index.ts
+++ b/polars/series/index.ts
@@ -25,7 +25,7 @@ import type {
   DtypeToJsName,
   JsToDtype,
   JsType,
-} from "@polars/datatypes/datatype";
+} from "../datatypes/datatype";
 
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 /**


### PR DESCRIPTION
# Bug Example

Trying to build my project with `"nodejs-polars": "^0.15.0"` as a dependency gives the following error

```
node_modules/nodejs-polars/bin/series/index.d.ts:9:66 - error TS2307: Cannot find module '@polars/datatypes/datatype' or its corresponding type declarations.

9 import type { DTypeToJs, DtypeToJsName, JsToDtype, JsType } from "@polars/datatypes/datatype";
                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

On inspecting the source TS files I see TS is complaining that the path doesn't exist. 

![Screenshot 2024-09-21 at 11 06 33 AM](https://github.com/user-attachments/assets/e8389229-5d33-46a3-8c06-c4c1bc120571)

This bug will not show up in development on this repo because the `@polars` alias is correctly defined in `tsconfig.json` but the distributed source code doesn't know anything about this path alias.


# Testing
- updated the path
- successfully build my project
- test loading a CSV file
- On branch of the source code I ran `yarn build:ts` and `yarn test` and both succeeded

![Screenshot 2024-09-21 at 11 07 41 AM](https://github.com/user-attachments/assets/a7bc57ef-b7b1-4795-936e-717cd23dbb93)

![Screenshot 2024-09-21 at 11 08 18 AM](https://github.com/user-attachments/assets/abc4169d-45c2-4948-8055-89c24a5bc5d5)
