### PR TITLE
Adding allowMissingColumns to ScanParquetOptions

### DIFF
--- a/polars/types.ts
+++ b/polars/types.ts
@@ -156,6 +156,7 @@ export interface ScanParquetOptions {
   cloudOptions?: unknown;
   retries?: number;
   includeFilePaths?: string;
+  allowMissingColumns?: boolean;
 }
 
 /**


### PR DESCRIPTION
Adding allowMissingColumns to ScanParquetOptions to close #284 