### PR TITLE
feat: switch DataFrame generic to its schema

### DIFF
--- a/__tests__/type.test.ts
+++ b/__tests__/type.test.ts
@@ -1,0 +1,109 @@
+import { expectType } from "ts-expect";
+
+import pl from "@polars/index";
+
+describe("type tests", () => {
+  it("types the DataFrame from the input", () => {
+    const df = pl.DataFrame({
+      bools: [false, true, false],
+      bools_nulls: [null, true, false],
+      int: [1, 2, 3],
+      int_nulls: [1, null, 3],
+      bigint: [1n, 2n, 3n],
+      bigint_nulls: [1n, null, 3n],
+      floats: [1.0, 2.0, 3.0],
+      floats_nulls: [1.0, null, 3.0],
+      strings: ["foo", "bar", "ham"],
+      strings_nulls: ["foo", null, "ham"],
+      date: [new Date(), new Date(), new Date()],
+      datetime: [13241324, 12341256, 12341234],
+    });
+
+    expectType<
+      pl.DataFrame<{
+        bools: pl.Bool;
+        bools_nulls: pl.Bool;
+        int: pl.Float64;
+        int_nulls: pl.Float64;
+        bigint: pl.UInt64;
+        bigint_nulls: pl.UInt64;
+        floats: pl.Float64;
+        floats_nulls: pl.Float64;
+        strings: pl.String;
+        strings_nulls: pl.String;
+        date: pl.Datetime;
+        datetime: pl.Float64;
+      }>
+    >(df);
+  });
+
+  it("produces the expected types", () => {
+    const a = pl.DataFrame({
+      id: [1n, 2n],
+      age: [18n, 19n],
+      name: ["A", "B"],
+    });
+    const b = pl.DataFrame({
+      id: [1n, 2n],
+      age: [18n, 19n],
+      fl: [1.3, 3.4],
+    });
+    expectType<pl.Series<pl.UInt64, "age">>(a.getColumn("age"));
+    expectType<
+      (
+        | pl.Series<pl.UInt64, "id">
+        | pl.Series<pl.UInt64, "age">
+        | pl.Series<pl.String, "name">
+      )[]
+    >(a.getColumns());
+    expectType<pl.DataFrame<{ id: pl.UInt64; age: pl.UInt64 }>>(a.drop("name"));
+    expectType<pl.DataFrame<{ id: pl.UInt64 }>>(a.drop(["name", "age"]));
+    expectType<pl.DataFrame<{ id: pl.UInt64 }>>(a.drop("name", "age"));
+    expectType<
+      pl.DataFrame<{
+        id: pl.UInt64;
+        age: pl.UInt64;
+        age_right: pl.UInt64;
+        name: pl.String;
+        fl: pl.Float64;
+      }>
+    >(a.join(b, { on: ["id"] }));
+    expectType<
+      pl.DataFrame<{
+        id: pl.UInt64;
+        age: pl.UInt64;
+        ageRight: pl.UInt64;
+        name: pl.String;
+        fl: pl.Float64;
+      }>
+    >(a.join(b, { on: ["id"], suffix: "Right" }));
+    expectType<
+      pl.DataFrame<{
+        id: pl.UInt64;
+        id_right: pl.UInt64;
+        age: pl.UInt64;
+        name: pl.String;
+        fl: pl.Float64;
+      }>
+    >(a.join(b, { leftOn: "id", rightOn: ["age"] }));
+    expectType<
+      pl.DataFrame<{
+        id: pl.UInt64;
+        id_right: pl.UInt64;
+        age: pl.UInt64;
+        age_right: pl.UInt64;
+        name: pl.String;
+        fl: pl.Float64;
+      }>
+    >(a.join(b, { how: "cross" }));
+  });
+
+  it("folds", () => {
+    const df = pl.DataFrame({
+      a: [2, 1, 3],
+      b: [1, 2, 3],
+      c: [1.0, 2.0, 3.0],
+    });
+    expectType<pl.Series<pl.Float64, string>>(df.fold((s1, s2) => s1.plus(s2)));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "chance": "^1.1.13",
     "jest": "^29.7.0",
     "source-map-support": "^0.5.21",
+    "ts-expect": "^1.3.0",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.4",

--- a/polars/dataframe.ts
+++ b/polars/dataframe.ts
@@ -180,6 +180,50 @@ interface WriteMethods {
   writeAvro(options?: WriteAvroOptions): Buffer;
 }
 
+export type Schema = Record<string, DataType>;
+type SchemaToSeriesRecord<T extends Record<string, DataType>> = {
+  [K in keyof T]: K extends string ? Series<T[K], K> : never;
+};
+type ArrayLikeLooseRecordToSchema<T extends Record<string, ArrayLike<any>>> = {
+  [K in keyof T]: K extends string
+    ? T[K] extends ArrayLike<infer V>
+      ? V extends DataType
+        ? V
+        : JsToDtype<V>
+      : never
+    : never;
+};
+
+type ExtractJoinKeys<T> = T extends string[] ? T[number] : T;
+type ExtractSuffix<T extends JoinOptions> = T extends { suffix: infer Suffix }
+  ? Suffix
+  : "_right";
+export type JoinSchemas<
+  S1 extends Schema,
+  S2 extends Schema,
+  Opt extends JoinOptions,
+> = Simplify<
+  {
+    [K1 in keyof S1]: S1[K1];
+  } & {
+    [K2 in Exclude<keyof S2, keyof S1>]: K2 extends keyof S1 ? never : S2[K2];
+  } & {
+    [K_SUFFIXED in keyof S1 &
+      Exclude<
+        keyof S2,
+        Opt extends { how: "cross" }
+          ? never
+          : Opt extends Pick<JoinOptions, "on">
+            ? ExtractJoinKeys<Opt["on"]>
+            : Opt extends Pick<JoinOptions, "leftOn" | "rightOn">
+              ? ExtractJoinKeys<Opt["rightOn"]>
+              : never
+      > as `${K_SUFFIXED extends string ? K_SUFFIXED : never}${ExtractSuffix<Opt>}`]: K_SUFFIXED extends string
+      ? S2[K_SUFFIXED]
+      : never;
+  }
+>;
+
 /**
  * A DataFrame is a two-dimensional data structure that represents data as a table
  * with rows and columns.
@@ -251,10 +295,9 @@ interface WriteMethods {
  * ╰─────┴─────┴─────╯
  * ```
  */
-export interface DataFrame<T extends Record<string, Series> = any>
-  extends Arithmetic<DataFrame<T>>,
-    Sample<DataFrame<T>>,
-    Arithmetic<DataFrame<T>>,
+export interface DataFrame<S extends Schema = any>
+  extends Arithmetic<DataFrame<S>>,
+    Sample<DataFrame<S>>,
     WriteMethods,
     Serialize,
     GroupByOps<RollingGroupBy> {
@@ -271,7 +314,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
   /**
    * Very cheap deep clone.
    */
-  clone(): DataFrame<T>;
+  clone(): DataFrame<S>;
   /**
    * __Summary statistics for a DataFrame.__
    *
@@ -342,14 +385,14 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────╯
    * ```
    */
-  drop<U extends string>(name: U): DataFrame<Simplify<Omit<T, U>>>;
+  drop<U extends string>(name: U): DataFrame<Simplify<Omit<S, U>>>;
   drop<const U extends string[]>(
     names: U,
-  ): DataFrame<Simplify<Omit<T, U[number]>>>;
+  ): DataFrame<Simplify<Omit<S, U[number]>>>;
   drop<U extends string, const V extends string[]>(
     name: U,
     ...names: V
-  ): DataFrame<Simplify<Omit<T, U | V[number]>>>;
+  ): DataFrame<Simplify<Omit<S, U | V[number]>>>;
   /**
    * __Return a new DataFrame where the null values are dropped.__
    *
@@ -375,9 +418,9 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * └─────┴─────┴─────┘
    * ```
    */
-  dropNulls(column: keyof T): DataFrame<T>;
-  dropNulls(columns: (keyof T)[]): DataFrame<T>;
-  dropNulls(...columns: (keyof T)[]): DataFrame<T>;
+  dropNulls(column: keyof S): DataFrame<S>;
+  dropNulls(columns: (keyof S)[]): DataFrame<S>;
+  dropNulls(...columns: (keyof S)[]): DataFrame<S>;
   /**
    * __Explode `DataFrame` to long format by exploding a column with Lists.__
    * ___
@@ -460,7 +503,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
 
    * @param other DataFrame to vertically add.
    */
-  extend(other: DataFrame<T>): DataFrame<T>;
+  extend(other: DataFrame<S>): DataFrame<S>;
   /**
    * Fill null/missing values by a filling strategy
    *
@@ -474,7 +517,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    *   - "one"
    * @returns DataFrame with None replaced with the filling strategy.
    */
-  fillNull(strategy: FillNullStrategy): DataFrame<T>;
+  fillNull(strategy: FillNullStrategy): DataFrame<S>;
   /**
    * Filter the rows in the DataFrame based on a predicate expression.
    * ___
@@ -513,7 +556,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * └─────┴─────┴─────┘
    * ```
    */
-  filter(predicate: any): DataFrame<T>;
+  filter(predicate: any): DataFrame<S>;
   /**
    * Find the index of a column by name.
    * ___
@@ -529,7 +572,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * 2
    * ```
    */
-  findIdxByName(name: keyof T): number;
+  findIdxByName(name: keyof S): number;
   /**
    * __Apply a horizontal reduction on a DataFrame.__
    *
@@ -586,7 +629,13 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ]
    * ```
    */
-  fold(operation: (s1: Series, s2: Series) => Series): Series;
+  fold<
+    D extends DataType,
+    F extends (
+      s1: SchemaToSeriesRecord<S>[keyof S] | Series<D>,
+      s2: SchemaToSeriesRecord<S>[keyof S],
+    ) => Series<D>,
+  >(operation: F): Series<D>;
   /**
    * Check if DataFrame is equal to other.
    * ___
@@ -632,7 +681,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * // column: pl.Series<Float64, "foo">
    * ```
    */
-  getColumn<U extends keyof T>(name: U): T[U];
+  getColumn<U extends keyof S>(name: U): SchemaToSeriesRecord<S>[U];
   getColumn(name: string): Series;
   /**
    * Get the DataFrame as an Array of Series.
@@ -653,7 +702,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * // columns: (pl.Series<Float64, "foo"> | pl.Series<Float64, "bar"> | pl.Series<Utf8, "ham">)[]
    * ```
    */
-  getColumns(): T[keyof T][];
+  getColumns(): SchemaToSeriesRecord<S>[keyof S][];
   /**
    * Start a groupby operation.
    * ___
@@ -700,7 +749,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴─────╯
    * ```
    */
-  head(length?: number): DataFrame<T>;
+  head(length?: number): DataFrame<S>;
   /**
    * Return a new DataFrame grown horizontally by stacking multiple Series to it.
    * @param columns - array of Series or DataFrame to stack
@@ -741,13 +790,13 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ```
    */
   hstack(columns: Array<Series> | DataFrame, inPlace?: boolean): void;
-  hstack<U extends Record<string, Series> = any>(
-    columns: DataFrame<U>,
-  ): DataFrame<Simplify<T & U>>;
+  hstack<S2 extends Schema = Schema>(
+    columns: DataFrame<S2>,
+  ): DataFrame<Simplify<S & S2>>;
   hstack<U extends Series[]>(
     columns: U,
-  ): DataFrame<Simplify<T & { [K in U[number] as K["name"]]: K }>>;
-  hstack(columns: Array<Series> | DataFrame): DataFrame;
+  ): DataFrame<Simplify<S & { [K in U[number] as K["name"]]: K }>>;
+  hstack(columns: Array<Series> | DataFrame, inPlace?: boolean): void;
   /**
    * Insert a Series at a certain column index. This operation is in place.
    * @param index - Column position to insert the new `Series` column.
@@ -757,7 +806,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
   /**
    * Interpolate intermediate values. The interpolation method is linear.
    */
-  interpolate(): DataFrame<T>;
+  interpolate(): DataFrame<S>;
   /**
    * Get a mask of all duplicated rows in this DataFrame.
    */
@@ -804,21 +853,24 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴─────┴───────╯
    * ```
    */
-  join(
-    other: DataFrame,
-    options: { on: ValueOrArray<string> } & Omit<
+  join<
+    S2 extends Schema,
+    const Opts extends { on: ValueOrArray<keyof S & keyof S2> } & Omit<
       JoinOptions,
       "leftOn" | "rightOn"
     >,
-  ): DataFrame;
-  join(
-    other: DataFrame,
-    options: {
-      leftOn: ValueOrArray<string>;
-      rightOn: ValueOrArray<string>;
+  >(other: DataFrame<S2>, options: Opts): DataFrame<JoinSchemas<S, S2, Opts>>;
+  join<
+    S2 extends Schema,
+    const Opts extends {
+      leftOn: ValueOrArray<keyof S>;
+      rightOn: ValueOrArray<keyof S2>;
     } & Omit<JoinOptions, "on">,
-  ): DataFrame;
-  join(other: DataFrame, options: { how: "cross"; suffix?: string }): DataFrame;
+  >(other: DataFrame<S2>, options: Opts): DataFrame<JoinSchemas<S, S2, Opts>>;
+  join<S2 extends Schema, const Opts extends { how: "cross"; suffix?: string }>(
+    other: DataFrame<S2>,
+    options: Opts,
+  ): DataFrame<JoinSchemas<S, S2, Opts>>;
 
   /**
    * Perform an asof join. This is similar to a left-join except that we
@@ -925,12 +977,12 @@ export interface DataFrame<T extends Record<string, Series> = any>
       forceParallel?: boolean;
     },
   ): DataFrame;
-  lazy(): LazyDataFrame;
+  lazy(): LazyDataFrame<S>;
   /**
    * Get first N rows as DataFrame.
    * @see {@link head}
    */
-  limit(length?: number): DataFrame<T>;
+  limit(length?: number): DataFrame<S>;
   map<ReturnT>(
     // TODO: strong types for the mapping function
     func: (row: any[], i: number, arr: any[][]) => ReturnT,
@@ -958,9 +1010,9 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴──────╯
    * ```
    */
-  max(axis: 0): DataFrame<T>;
+  max(axis: 0): DataFrame<S>;
   max(axis: 1): Series;
-  max(): DataFrame<T>;
+  max(): DataFrame<S>;
   /**
    * Aggregate the columns of this DataFrame to their mean value.
    * ___
@@ -969,8 +1021,8 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * @param nullStrategy - this argument is only used if axis == 1
    */
   mean(axis: 1, nullStrategy?: "ignore" | "propagate"): Series;
-  mean(): DataFrame<T>;
-  mean(axis: 0): DataFrame<T>;
+  mean(): DataFrame<S>;
+  mean(axis: 0): DataFrame<S>;
   mean(axis: 1): Series;
   /**
    * Aggregate the columns of this DataFrame to their median value.
@@ -993,7 +1045,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴──────╯
    * ```
    */
-  median(): DataFrame<T>;
+  median(): DataFrame<S>;
   /**
    * Unpivot a DataFrame from wide to long format.
    * ___
@@ -1055,9 +1107,9 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴──────╯
    * ```
    */
-  min(axis: 0): DataFrame<T>;
+  min(axis: 0): DataFrame<S>;
   min(axis: 1): Series;
-  min(): DataFrame<T>;
+  min(): DataFrame<S>;
   /**
    * Get number of chunks used by the ChunkedArrays of this DataFrame.
    */
@@ -1084,13 +1136,13 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ```
    */
   nullCount(): DataFrame<{
-    [K in keyof T]: Series<JsToDtype<number>, K & string>;
+    [K in keyof S]: JsToDtype<number>;
   }>;
   partitionBy(
     cols: string | string[],
     stable?: boolean,
     includeKey?: boolean,
-  ): DataFrame<T>[];
+  ): DataFrame<S>[];
   partitionBy<T>(
     cols: string | string[],
     stable: boolean,
@@ -1208,13 +1260,13 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴──────╯
    * ```
    */
-  quantile(quantile: number): DataFrame<T>;
+  quantile(quantile: number): DataFrame<S>;
   /**
    * __Rechunk the data in this DataFrame to a contiguous allocation.__
    *
    * This will make sure all subsequent operations have optimal and predictable performance.
    */
-  rechunk(): DataFrame<T>;
+  rechunk(): DataFrame<S>;
   /**
    * __Rename column names.__
    * ___
@@ -1246,9 +1298,9 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰───────┴─────┴─────╯
    * ```
    */
-  rename<const U extends Partial<Record<keyof T, string>>>(
+  rename<const U extends Partial<Record<keyof S, string>>>(
     mapping: U,
-  ): DataFrame<{ [K in keyof T as U[K] extends string ? U[K] : K]: T[K] }>;
+  ): DataFrame<{ [K in keyof S as U[K] extends string ? U[K] : K]: S[K] }>;
   rename(mapping: Record<string, string>): DataFrame;
   /**
    * Replace a column at an index location.
@@ -1333,7 +1385,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * // }
    * ```
    */
-  get schema(): { [K in keyof T]: T[K]["dtype"] };
+  get schema(): S;
   /**
    * Select columns from this DataFrame.
    * ___
@@ -1368,8 +1420,8 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * └─────┘
    * ```
    */
-  select<U extends keyof T>(...columns: U[]): DataFrame<{ [P in U]: T[P] }>;
-  select(...columns: ExprOrString[]): DataFrame<T>;
+  select<U extends keyof S>(...columns: U[]): DataFrame<{ [P in U]: S[P] }>;
+  select(...columns: ExprOrString[]): DataFrame<S>;
   /**
    * Shift the values by a given period and fill the parts that will be empty due to this operation
    * with `Nones`.
@@ -1410,8 +1462,8 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * └──────┴──────┴──────┘
    * ```
    */
-  shift(periods: number): DataFrame<T>;
-  shift({ periods }: { periods: number }): DataFrame<T>;
+  shift(periods: number): DataFrame<S>;
+  shift({ periods }: { periods: number }): DataFrame<S>;
   /**
    * Shift the values by a given period and fill the parts that will be empty due to this operation
    * with the result of the `fill_value` expression.
@@ -1440,15 +1492,18 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * └─────┴─────┴─────┘
    * ```
    */
-  shiftAndFill(n: number, fillValue: number): DataFrame<T>;
+  shiftAndFill(n: number, fillValue: number): DataFrame<S>;
   shiftAndFill({
     n,
     fillValue,
-  }: { n: number; fillValue: number }): DataFrame<T>;
+  }: {
+    n: number;
+    fillValue: number;
+  }): DataFrame<S>;
   /**
    * Shrink memory usage of this DataFrame to fit the exact capacity needed to hold the data.
    */
-  shrinkToFit(): DataFrame<T>;
+  shrinkToFit(): DataFrame<S>;
   shrinkToFit(inPlace: true): void;
   shrinkToFit({ inPlace }: { inPlace: true }): void;
   /**
@@ -1477,8 +1532,8 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * └─────┴─────┴─────┘
    * ```
    */
-  slice({ offset, length }: { offset: number; length: number }): DataFrame<T>;
-  slice(offset: number, length: number): DataFrame<T>;
+  slice({ offset, length }: { offset: number; length: number }): DataFrame<S>;
+  slice(offset: number, length: number): DataFrame<S>;
   /**
    * Sort the DataFrame by column.
    * ___
@@ -1492,7 +1547,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
     descending?: boolean,
     nullsLast?: boolean,
     maintainOrder?: boolean,
-  ): DataFrame<T>;
+  ): DataFrame<S>;
   sort({
     by,
     reverse, // deprecated
@@ -1503,7 +1558,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
     reverse?: boolean; // deprecated
     nullsLast?: boolean;
     maintainOrder?: boolean;
-  }): DataFrame<T>;
+  }): DataFrame<S>;
   sort({
     by,
     descending,
@@ -1513,7 +1568,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
     descending?: boolean;
     nullsLast?: boolean;
     maintainOrder?: boolean;
-  }): DataFrame<T>;
+  }): DataFrame<S>;
   /**
    * Aggregate the columns of this DataFrame to their standard deviation value.
    * ___
@@ -1535,7 +1590,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴──────╯
    * ```
    */
-  std(): DataFrame<T>;
+  std(): DataFrame<S>;
   /**
    * Aggregate the columns of this DataFrame to their mean value.
    * ___
@@ -1544,8 +1599,8 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * @param nullStrategy - this argument is only used if axis == 1
    */
   sum(axis: 1, nullStrategy?: "ignore" | "propagate"): Series;
-  sum(): DataFrame<T>;
-  sum(axis: 0): DataFrame<T>;
+  sum(): DataFrame<S>;
+  sum(axis: 0): DataFrame<S>;
   sum(axis: 1): Series;
   /**
    * @example
@@ -1594,7 +1649,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────────┴─────╯
    * ```
    */
-  tail(length?: number): DataFrame<T>;
+  tail(length?: number): DataFrame<S>;
   /**
    * Converts dataframe object into row oriented javascript objects
    * @example
@@ -1608,7 +1663,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ```
    * @category IO
    */
-  toRecords(): { [K in keyof T]: DTypeToJs<T[K]["dtype"]> | null }[];
+  toRecords(): { [K in keyof S]: DTypeToJs<S[K]> | null }[];
   /**
    * Converts dataframe object into a {@link TabularDataResource}
    */
@@ -1631,8 +1686,8 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ```
    * @category IO
    */
-  toObject(): { [K in keyof T]: DTypeToJs<T[K]["dtype"] | null>[] };
-  toSeries(index?: number): T[keyof T];
+  toObject(): { [K in keyof S]: DTypeToJs<S[K] | null>[] };
+  toSeries(index?: number): SchemaToSeriesRecord<S>[keyof S];
   toString(): string;
   /**
    *  Convert a ``DataFrame`` to a ``Series`` of type ``Struct``
@@ -1744,12 +1799,12 @@ export interface DataFrame<T extends Record<string, Series> = any>
     maintainOrder?: boolean,
     subset?: ColumnSelection,
     keep?: "first" | "last",
-  ): DataFrame<T>;
+  ): DataFrame<S>;
   unique(opts: {
     maintainOrder?: boolean;
     subset?: ColumnSelection;
     keep?: "first" | "last";
-  }): DataFrame<T>;
+  }): DataFrame<S>;
   /**
       Decompose a struct into its fields. The fields will be inserted in to the `DataFrame` on the
       location of the `struct` type.
@@ -1809,7 +1864,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴──────╯
    * ```
    */
-  var(): DataFrame<T>;
+  var(): DataFrame<S>;
   /**
    * Grow this DataFrame vertically by stacking a DataFrame to it.
    * @param df - DataFrame to stack.
@@ -1842,16 +1897,14 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * ╰─────┴─────┴─────╯
    * ```
    */
-  vstack(df: DataFrame<T>): DataFrame<T>;
+  vstack(df: DataFrame<S>): DataFrame<S>;
   /**
    * Return a new DataFrame with the column added or replaced.
    * @param column - Series, where the name of the Series refers to the column in the DataFrame.
    */
   withColumn<SeriesTypeT extends DataType, SeriesNameT extends string>(
     column: Series<SeriesTypeT, SeriesNameT>,
-  ): DataFrame<
-    Simplify<T & { [K in SeriesNameT]: Series<SeriesTypeT, SeriesNameT> }>
-  >;
+  ): DataFrame<Simplify<S & { [K in SeriesNameT]: SeriesTypeT }>>;
   withColumn(column: Series | Expr): DataFrame;
   withColumns(...columns: (Expr | Series)[]): DataFrame;
   /**
@@ -1859,16 +1912,16 @@ export interface DataFrame<T extends Record<string, Series> = any>
    * @param existingName
    * @param replacement
    */
-  withColumnRenamed<Existing extends keyof T, New extends string>(
+  withColumnRenamed<Existing extends keyof S, New extends string>(
     existingName: Existing,
     replacement: New,
-  ): DataFrame<{ [K in keyof T as K extends Existing ? New : K]: T[K] }>;
+  ): DataFrame<{ [K in keyof S as K extends Existing ? New : K]: S[K] }>;
   withColumnRenamed(existing: string, replacement: string): DataFrame;
 
-  withColumnRenamed<Existing extends keyof T, New extends string>(opts: {
+  withColumnRenamed<Existing extends keyof S, New extends string>(opts: {
     existingName: Existing;
     replacement: New;
-  }): DataFrame<{ [K in keyof T as K extends Existing ? New : K]: T[K] }>;
+  }): DataFrame<{ [K in keyof S as K extends Existing ? New : K]: S[K] }>;
   withColumnRenamed(opts: { existing: string; replacement: string }): DataFrame;
   /**
    * Add a column at index 0 that counts the rows.
@@ -1876,7 +1929,7 @@ export interface DataFrame<T extends Record<string, Series> = any>
    */
   withRowCount(name?: string): DataFrame;
   /** @see {@link filter} */
-  where(predicate: any): DataFrame<T>;
+  where(predicate: any): DataFrame<S>;
   /**
     Upsample a DataFrame at a regular frequency.
 
@@ -1952,13 +2005,13 @@ shape: (7, 3)
     every: string,
     by?: string | string[],
     maintainOrder?: boolean,
-  ): DataFrame<T>;
+  ): DataFrame<S>;
   upsample(opts: {
     timeColumn: string;
     every: string;
     by?: string | string[];
     maintainOrder?: boolean;
-  }): DataFrame<T>;
+  }): DataFrame<S>;
 }
 
 function prepareOtherArg(anyValue: any): Series {
@@ -2014,11 +2067,11 @@ function mapPolarsTypeToJSONSchema(colType: DataType): string {
 }
 
 /** @ignore */
-export const _DataFrame = (_df: any): DataFrame => {
+export const _DataFrame = <S extends Schema>(_df: any): DataFrame<S> => {
   const unwrap = (method: string, ...args: any[]) => {
     return _df[method as any](...args);
   };
-  const wrap = (method, ...args): DataFrame => {
+  const wrap = (method, ...args): DataFrame<any> => {
     return _DataFrame(unwrap(method, ...args));
   };
 
@@ -2078,7 +2131,7 @@ export const _DataFrame = (_df: any): DataFrame => {
         "text/html": limited.toHTML(),
       };
     },
-    get schema() {
+    get schema(): any {
       return this.getColumns().reduce((acc, curr) => {
         acc[curr.name] = curr.dtype;
 
@@ -2089,7 +2142,7 @@ export const _DataFrame = (_df: any): DataFrame => {
       return wrap("clone");
     },
     describe() {
-      const describeCast = (df: DataFrame) => {
+      const describeCast = (df: DataFrame<S>) => {
         return DataFrame(
           df.getColumns().map((s) => {
             if (s.isNumeric() || s.isBoolean()) {
@@ -2105,7 +2158,7 @@ export const _DataFrame = (_df: any): DataFrame => {
         describeCast(this.min()),
         describeCast(this.max()),
         describeCast(this.median()),
-      ]);
+      ] as any);
       summary.insertAtIdx(
         0,
         Series("describe", ["mean", "std", "min", "max", "median"]),
@@ -2167,7 +2220,7 @@ export const _DataFrame = (_df: any): DataFrame => {
     findIdxByName(name) {
       return unwrap("findIdxByName", name);
     },
-    fold(fn: (s1, s2) => Series) {
+    fold(fn: (s1, s2) => any) {
       if (this.width === 1) {
         return this.toSeries(0);
       }
@@ -2220,7 +2273,7 @@ export const _DataFrame = (_df: any): DataFrame => {
         startBy,
       );
     },
-    upsample(opts, every?, by?, maintainOrder?) {
+    upsample(opts, every?, by?, maintainOrder?): any {
       let timeColumn;
       if (typeof opts === "string") {
         timeColumn = opts;
@@ -2274,7 +2327,7 @@ export const _DataFrame = (_df: any): DataFrame => {
     isDuplicated: () => _Series(_df.isDuplicated()) as any,
     isEmpty: () => _df.height === 0,
     isUnique: () => _Series(_df.isUnique()) as any,
-    join(other: DataFrame, options): DataFrame {
+    join(other, options): any {
       options = { how: "inner", ...options };
       const on = columnOrColumns(options.on);
       const how = options.how;
@@ -2301,7 +2354,7 @@ export const _DataFrame = (_df: any): DataFrame => {
         .joinAsof(other.lazy(), options as any)
         .collectSync();
     },
-    lazy: () => _LazyDataFrame(_df.lazy()),
+    lazy: () => _LazyDataFrame(_df.lazy()) as unknown as LazyDataFrame<S>,
     limit: (length = 5) => wrap("head", length),
     max(axis = 0) {
       if (axis === 1) {
@@ -2410,7 +2463,7 @@ export const _DataFrame = (_df: any): DataFrame => {
     rechunk() {
       return wrap("rechunk");
     },
-    rename(mapping) {
+    rename(mapping): any {
       const df = this.clone();
       for (const [column, new_col] of Object.entries(mapping)) {
         (df as any).inner().rename(column, new_col);
@@ -2471,7 +2524,7 @@ export const _DataFrame = (_df: any): DataFrame => {
       return wrap("select", columnOrColumnsStrict(selection as any));
     },
     shift: (opt) => wrap("shift", opt?.periods ?? opt),
-    shiftAndFill(n: any, fillValue?: number | undefined) {
+    shiftAndFill(n: any, fillValue?: number | undefined): any {
       if (typeof n === "number" && fillValue) {
         return _DataFrame(_df).lazy().shiftAndFill(n, fillValue).collectSync();
       }
@@ -2577,7 +2630,7 @@ export const _DataFrame = (_df: any): DataFrame => {
 
       return { data, schema: { fields } };
     },
-    toObject() {
+    toObject(): any {
       return this.getColumns().reduce((acc, curr) => {
         acc[curr.name] = curr.toArray();
 
@@ -2734,7 +2787,7 @@ export const _DataFrame = (_df: any): DataFrame => {
         .withColumns(columns)
         .collectSync({ noOptimization: true });
     },
-    withColumnRenamed(opt, replacement?) {
+    withColumnRenamed(opt, replacement?): any {
       if (typeof opt === "string") {
         return this.rename({ [opt]: replacement });
       }
@@ -2757,10 +2810,10 @@ export const _DataFrame = (_df: any): DataFrame => {
     divideBy: (other) => wrap("div", prepareOtherArg(other).inner()),
     multiplyBy: (other) => wrap("mul", prepareOtherArg(other).inner()),
     modulo: (other) => wrap("rem", prepareOtherArg(other).inner()),
-  } as DataFrame;
+  } as DataFrame<S>;
 
   return new Proxy(df, {
-    get(target: DataFrame, prop, receiver) {
+    get(target: DataFrame<S>, prop, receiver) {
       if (typeof prop === "string" && target.columns.includes(prop)) {
         return target.getColumn(prop);
       }
@@ -2769,7 +2822,7 @@ export const _DataFrame = (_df: any): DataFrame => {
       }
       return Reflect.get(target, prop, receiver);
     },
-    set(target: DataFrame, prop, receiver) {
+    set(target: DataFrame<S>, prop, receiver) {
       if (Series.isSeries(receiver)) {
         if (typeof prop === "string" && target.columns.includes(prop)) {
           const idx = target.columns.indexOf(prop);
@@ -2802,11 +2855,14 @@ export const _DataFrame = (_df: any): DataFrame => {
   });
 };
 
-interface DataFrameOptions {
+interface DataFrameOptions<
+  S extends Schema = Schema,
+  O extends Partial<S> = any,
+> {
   columns?: any[];
   orient?: "row" | "col";
-  schema?: Record<string, string | DataType>;
-  schemaOverrides?: Record<string, string | DataType>;
+  schema?: S;
+  schemaOverrides?: O;
   inferSchemaLength?: number;
 }
 
@@ -2863,21 +2919,25 @@ export interface DataFrameConstructor extends Deserialize<DataFrame> {
     data: T1,
     options?: DataFrameOptions,
   ): DataFrame<{
-    [K in T1[number] as K["name"]]: K;
+    [K in T1[number] as K["name"]]: K["dtype"];
   }>;
-  <T2 extends Record<string, ArrayLike<any>>>(
-    data: T2,
-    options?: DataFrameOptions,
-  ): DataFrame<{
-    [K in keyof T2]: K extends string
-      ? Series<JsToDtype<T2[K][number]>, K>
-      : never;
-  }>;
+  <
+    RecordInput extends Record<string, ArrayLike<any>> = any,
+    S extends Simplify<ArrayLikeLooseRecordToSchema<RecordInput>> = Simplify<
+      ArrayLikeLooseRecordToSchema<RecordInput>
+    >,
+  >(
+    data: RecordInput,
+    options?: DataFrameOptions<S>,
+  ): DataFrame<S>;
   (data: any, options?: DataFrameOptions): DataFrame;
   isDataFrame(arg: any): arg is DataFrame;
 }
 
-function DataFrameConstructor(data?, options?): DataFrame {
+function DataFrameConstructor<S extends Schema = Schema>(
+  data?,
+  options?,
+): DataFrame<S> {
   if (!data) {
     return _DataFrame(objToDF({}));
   }

--- a/polars/datatypes/conversion.ts
+++ b/polars/datatypes/conversion.ts
@@ -1,0 +1,13 @@
+import type { DataType } from "./datatype";
+
+export type JsToDtype<T> = T extends bigint
+  ? DataType.UInt64
+  : T extends number
+    ? DataType.Float64
+    : T extends boolean
+      ? DataType.Bool
+      : T extends string
+        ? DataType.String
+        : T extends Date
+          ? DataType.Datetime
+          : never;

--- a/polars/datatypes/datatype.ts
+++ b/polars/datatypes/datatype.ts
@@ -1,7 +1,7 @@
 import { Field } from "./field";
 
-export abstract class DataType {
-  declare readonly __dtype: string;
+export abstract class DataType<Dtype extends DataTypeName = any> {
+  declare readonly __dtype: Dtype;
   get variant() {
     return this.constructor.name as DataTypeName;
   }
@@ -164,67 +164,67 @@ export abstract class DataType {
   }
 }
 
-export class Null extends DataType {
+export class Null extends DataType<"Null"> {
   declare __dtype: "Null";
 }
 
-export class Bool extends DataType {
+export class Bool extends DataType<"Bool"> {
   declare __dtype: "Bool";
 }
-export class Int8 extends DataType {
+export class Int8 extends DataType<"Int8"> {
   declare __dtype: "Int8";
 }
-export class Int16 extends DataType {
+export class Int16 extends DataType<"Int16"> {
   declare __dtype: "Int16";
 }
-export class Int32 extends DataType {
+export class Int32 extends DataType<"Int32"> {
   declare __dtype: "Int32";
 }
-export class Int64 extends DataType {
+export class Int64 extends DataType<"Int64"> {
   declare __dtype: "Int64";
 }
-export class UInt8 extends DataType {
+export class UInt8 extends DataType<"UInt8"> {
   declare __dtype: "UInt8";
 }
-export class UInt16 extends DataType {
+export class UInt16 extends DataType<"UInt16"> {
   declare __dtype: "UInt16";
 }
-export class UInt32 extends DataType {
+export class UInt32 extends DataType<"UInt32"> {
   declare __dtype: "UInt32";
 }
-export class UInt64 extends DataType {
+export class UInt64 extends DataType<"UInt64"> {
   declare __dtype: "UInt64";
 }
-export class Float32 extends DataType {
+export class Float32 extends DataType<"Float32"> {
   declare __dtype: "Float32";
 }
-export class Float64 extends DataType {
+export class Float64 extends DataType<"Float64"> {
   declare __dtype: "Float64";
 }
 
 // biome-ignore lint/suspicious/noShadowRestrictedNames: <explanation>
-export class Date extends DataType {
+export class Date extends DataType<"Date"> {
   declare __dtype: "Date";
 }
-export class Time extends DataType {
+export class Time extends DataType<"Time"> {
   declare __dtype: "Time";
 }
-export class Object_ extends DataType {
+export class Object_ extends DataType<"Object"> {
   declare __dtype: "Object";
 }
-export class Utf8 extends DataType {
+export class Utf8 extends DataType<"Utf8"> {
   declare __dtype: "Utf8";
 }
 // biome-ignore lint/suspicious/noShadowRestrictedNames: <explanation>
-export class String extends DataType {
+export class String extends DataType<"String"> {
   declare __dtype: "String";
 }
 
-export class Categorical extends DataType {
+export class Categorical extends DataType<"Categorical"> {
   declare __dtype: "Categorical";
 }
 
-export class Decimal extends DataType {
+export class Decimal extends DataType<"Decimal"> {
   declare __dtype: "Decimal";
   private precision: number | null;
   private scale: number | null;
@@ -261,7 +261,7 @@ export class Decimal extends DataType {
 /**
  * Datetime type
  */
-export class Datetime extends DataType {
+export class Datetime extends DataType<"Datetime"> {
   declare __dtype: "Datetime";
   constructor(
     private timeUnit: TimeUnit | "ms" | "ns" | "us" = "ms",
@@ -284,7 +284,7 @@ export class Datetime extends DataType {
   }
 }
 
-export class List extends DataType {
+export class List extends DataType<"List"> {
   declare __dtype: "List";
   constructor(protected __inner: DataType) {
     super();
@@ -300,7 +300,7 @@ export class List extends DataType {
   }
 }
 
-export class FixedSizeList extends DataType {
+export class FixedSizeList extends DataType<"FixedSizeList"> {
   declare __dtype: "FixedSizeList";
   constructor(
     protected __inner: DataType,
@@ -334,7 +334,7 @@ export class FixedSizeList extends DataType {
   }
 }
 
-export class Struct extends DataType {
+export class Struct extends DataType<"Struct"> {
   declare __dtype: "Struct";
   private fields: Field[];
 
@@ -465,46 +465,59 @@ export type DataTypeName =
   | "Decimal"
   | "Date"
   | "Datetime"
+  | "Time"
+  | "Object"
   | "Utf8"
+  | "String"
   | "Categorical"
   | "List"
+  | "FixedSizeList"
   | "Struct";
 
 export type JsType = number | boolean | string;
-export type JsToDtype<T> = T extends number
-  ? DataType.Float64
-  : T extends boolean
-    ? DataType.Bool
-    : T extends string
-      ? DataType.Utf8
-      : never;
 export type DTypeToJs<T> = T extends DataType.Decimal
   ? bigint
   : T extends DataType.Float64
     ? number
-    : T extends DataType.Int64
-      ? bigint
-      : T extends DataType.Int32
-        ? number
-        : T extends DataType.Bool
-          ? boolean
-          : T extends DataType.Utf8
-            ? string
-            : never;
+    : T extends DataType.Float32
+      ? number
+      : T extends DataType.Int64
+        ? bigint
+        : T extends DataType.Int32
+          ? number
+          : T extends DataType.Int16
+            ? number
+            : T extends DataType.Int8
+              ? number
+              : T extends DataType.Bool
+                ? boolean
+                : T extends DataType.Utf8
+                  ? string
+                  : T extends DataType.String
+                    ? string
+                    : never;
 // some objects can be constructed with a looser JS type than they’d return when converted back to JS
 export type DTypeToJsLoose<T> = T extends DataType.Decimal
   ? number | bigint
   : T extends DataType.Float64
     ? number | bigint
-    : T extends DataType.Int64
+    : T extends DataType.Float32
       ? number | bigint
-      : T extends DataType.Int32
+      : T extends DataType.Int64
         ? number | bigint
-        : T extends DataType.Bool
-          ? boolean
-          : T extends DataType.Utf8
-            ? string
-            : never;
+        : T extends DataType.Int32
+          ? number | bigint
+          : T extends DataType.Int16
+            ? number | bigint
+            : T extends DataType.Int8
+              ? number | bigint
+              : T extends DataType.Bool
+                ? boolean
+                : T extends DataType.Utf8
+                  ? string
+                  : T extends DataType.String
+                    ? string
+                    : never;
 export type DtypeToJsName<T> = T extends DataType.Decimal
   ? "Decimal"
   : T extends DataType.Float64

--- a/polars/datatypes/index.ts
+++ b/polars/datatypes/index.ts
@@ -1,5 +1,6 @@
 export * from "./datatype";
 export { Field } from "./field";
+export * from "./conversion";
 
 import pli from "../internals/polars_internal";
 // biome-ignore lint/style/useImportType: <explanation>

--- a/polars/lazy/dataframe.ts
+++ b/polars/lazy/dataframe.ts
@@ -1,4 +1,9 @@
-import { type DataFrame, _DataFrame } from "../dataframe";
+import {
+  type DataFrame,
+  type JoinSchemas,
+  type Schema,
+  _DataFrame,
+} from "../dataframe";
 import pli from "../internals/polars_internal";
 import type { Series } from "../series";
 import type { Deserialize, GroupByOps, Serialize } from "../shared_traits";
@@ -12,6 +17,7 @@ import {
   type ColumnSelection,
   type ColumnsOrExpr,
   type ExprOrString,
+  type Simplify,
   type ValueOrArray,
   columnOrColumnsStrict,
   selectionToExprList,
@@ -24,7 +30,9 @@ const inspect = Symbol.for("nodejs.util.inspect.custom");
 /**
  * Representation of a Lazy computation graph / query.
  */
-export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
+export interface LazyDataFrame<S extends Schema = any>
+  extends Serialize,
+    GroupByOps<LazyGroupBy> {
   /** @ignore */
   _ldf: any;
   [inspect](): string;
@@ -33,8 +41,8 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
   /**
    * Cache the result once the execution of the physical plan hits this node.
    */
-  cache(): LazyDataFrame;
-  clone(): LazyDataFrame;
+  cache(): LazyDataFrame<S>;
+  clone(): LazyDataFrame<S>;
   /**
    *
    * Collect into a DataFrame.
@@ -57,8 +65,8 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    * @return DataFrame
    *
    */
-  collect(opts?: LazyOptions): Promise<DataFrame>;
-  collectSync(opts?: LazyOptions): DataFrame;
+  collect(opts?: LazyOptions): Promise<DataFrame<S>>;
+  collectSync(opts?: LazyOptions): DataFrame<S>;
   /**
    * A string representation of the optimized query plan.
    */
@@ -71,16 +79,21 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    * Remove one or multiple columns from a DataFrame.
    * @param name - column or list of columns to be removed
    */
-  drop(name: string): LazyDataFrame;
-  drop(names: string[]): LazyDataFrame;
-  drop(name: string, ...names: string[]): LazyDataFrame;
+  drop<U extends string>(name: U): LazyDataFrame<Simplify<Omit<S, U>>>;
+  drop<const U extends string[]>(
+    names: U,
+  ): LazyDataFrame<Simplify<Omit<S, U[number]>>>;
+  drop<U extends string, const V extends string[]>(
+    name: U,
+    ...names: V
+  ): LazyDataFrame<Simplify<Omit<S, U | V[number]>>>;
   /**
    * Drop rows with null values from this DataFrame.
    * This method only drops nulls row-wise if any single value of the row is null.
    */
-  dropNulls(column: string): LazyDataFrame;
-  dropNulls(columns: string[]): LazyDataFrame;
-  dropNulls(...columns: string[]): LazyDataFrame;
+  dropNulls(column: string): LazyDataFrame<S>;
+  dropNulls(columns: string[]): LazyDataFrame<S>;
+  dropNulls(...columns: string[]): LazyDataFrame<S>;
   /**
    * Explode lists to long format.
    */
@@ -109,16 +122,16 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
                 at any point without it being considered a breaking change.
    *
    */
-  fetch(numRows: number, opts: LazyOptions): Promise<DataFrame>;
-  fetch(numRows?: number): Promise<DataFrame>;
+  fetch(numRows: number, opts: LazyOptions): Promise<DataFrame<S>>;
+  fetch(numRows?: number): Promise<DataFrame<S>>;
   /** Behaves the same as fetch, but will perform the actions synchronously */
-  fetchSync(numRows?: number): DataFrame;
-  fetchSync(numRows: number, opts: LazyOptions): DataFrame;
+  fetchSync(numRows?: number): DataFrame<S>;
+  fetchSync(numRows: number, opts: LazyOptions): DataFrame<S>;
   /**
    * Fill missing values
    * @param fillValue value to fill the missing values with
    */
-  fillNull(fillValue: string | number | Expr): LazyDataFrame;
+  fillNull(fillValue: string | number | Expr): LazyDataFrame<S>;
   /**
    * Filter the rows in the DataFrame based on a predicate expression.
    * @param predicate - Expression that evaluates to a boolean Series.
@@ -143,11 +156,11 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    * └─────┴─────┴─────┘
    * ```
    */
-  filter(predicate: Expr | string): LazyDataFrame;
+  filter(predicate: Expr | string): LazyDataFrame<S>;
   /**
    * Get the first row of the DataFrame.
    */
-  first(): DataFrame;
+  first(): DataFrame<S>;
   /**
    * Start a groupby operation.
    */
@@ -160,7 +173,7 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    * Consider using the `fetch` operation.
    * The `fetch` operation will truly load the first `n`rows lazily.
    */
-  head(length?: number): LazyDataFrame;
+  head(length?: number): LazyDataFrame<S>;
   inner(): any;
   /**
    *  __SQL like joins.__
@@ -198,26 +211,38 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    * ╰─────┴─────┴─────┴───────╯
    * ```
    */
-  join(
-    other: LazyDataFrame,
-    joinOptions: { on: ValueOrArray<string | Expr> } & LazyJoinOptions,
-  ): LazyDataFrame;
-  join(
-    other: LazyDataFrame,
-    joinOptions: {
-      leftOn: ValueOrArray<string | Expr>;
-      rightOn: ValueOrArray<string | Expr>;
-    } & LazyJoinOptions,
-  ): LazyDataFrame;
-  join(
-    other: LazyDataFrame,
-    options: {
+  join<
+    S2 extends Schema,
+    const Opts extends { on: ValueOrArray<string | Expr> } & Omit<
+      LazyJoinOptions,
+      "leftOn" | "rightOn"
+    >,
+  >(
+    other: LazyDataFrame<S2>,
+    joinOptions: Opts,
+  ): LazyDataFrame<JoinSchemas<S, S2, Opts>>;
+  join<
+    S2 extends Schema,
+    const Opts extends {
+      leftOn: ValueOrArray<keyof S>;
+      rightOn: ValueOrArray<keyof S2>;
+    } & Omit<LazyJoinOptions, "on">,
+  >(
+    other: LazyDataFrame<S2>,
+    joinOptions: Opts,
+  ): LazyDataFrame<JoinSchemas<S, S2, Opts>>;
+  join<
+    S2 extends Schema,
+    const Opts extends {
       how: "cross";
       suffix?: string;
       allowParallel?: boolean;
       forceParallel?: boolean;
     },
-  ): LazyDataFrame;
+  >(
+    other: LazyDataFrame<S2>,
+    options: Opts,
+  ): LazyDataFrame<JoinSchemas<S, S2, Opts>>;
 
   /**
      * Perform an asof join. This is similar to a left-join except that we
@@ -331,23 +356,23 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
   /**
    * Get the last row of the DataFrame.
    */
-  last(): LazyDataFrame;
+  last(): LazyDataFrame<S>;
   /**
    * @see {@link head}
    */
-  limit(n?: number): LazyDataFrame;
+  limit(n?: number): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.max}
    */
-  max(): LazyDataFrame;
+  max(): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.mean}
    */
-  mean(): LazyDataFrame;
+  mean(): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.median}
    */
-  median(): LazyDataFrame;
+  median(): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.unpivot}
    */
@@ -366,43 +391,44 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
   /**
    * @see {@link DataFrame.min}
    */
-  min(): LazyDataFrame;
+  min(): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.quantile}
    */
-  quantile(quantile: number): LazyDataFrame;
+  quantile(quantile: number): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.rename}
    */
+  rename<const U extends Partial<Record<keyof S, string>>>(
+    mapping: U,
+  ): LazyDataFrame<{ [K in keyof S as U[K] extends string ? U[K] : K]: S[K] }>;
   rename(mapping: Record<string, string>): LazyDataFrame;
   /**
    * Reverse the DataFrame.
    */
-  reverse(): LazyDataFrame;
+  reverse(): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.select}
    */
+  select<U extends keyof S>(...columns: U[]): LazyDataFrame<{ [P in U]: S[P] }>;
   select(column: ExprOrString): LazyDataFrame;
   select(columns: ExprOrString[]): LazyDataFrame;
   select(...columns: ExprOrString[]): LazyDataFrame;
   /**
    * @see {@link DataFrame.shift}
    */
-  shift(periods: number): LazyDataFrame;
-  shift(opts: { periods: number }): LazyDataFrame;
+  shift(periods: number): LazyDataFrame<S>;
+  shift(opts: { periods: number }): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.shiftAndFill}
    */
-  shiftAndFill(n: number, fillValue: number): LazyDataFrame;
-  shiftAndFill(opts: {
-    n: number;
-    fillValue: number;
-  }): LazyDataFrame;
+  shiftAndFill(n: number, fillValue: number): LazyDataFrame<S>;
+  shiftAndFill(opts: { n: number; fillValue: number }): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.slice}
    */
-  slice(offset: number, length: number): LazyDataFrame;
-  slice(opts: { offset: number; length: number }): LazyDataFrame;
+  slice(offset: number, length: number): LazyDataFrame<S>;
+  slice(opts: { offset: number; length: number }): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.sort}
    */
@@ -411,26 +437,26 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
     descending?: ValueOrArray<boolean>,
     nullsLast?: boolean,
     maintainOrder?: boolean,
-  ): LazyDataFrame;
+  ): LazyDataFrame<S>;
   sort(opts: {
     by: ColumnsOrExpr;
     descending?: ValueOrArray<boolean>;
     nullsLast?: boolean;
     maintainOrder?: boolean;
-  }): LazyDataFrame;
+  }): LazyDataFrame<S>;
   /**
    * @see {@link DataFrame.std}
    */
-  std(): LazyDataFrame;
+  std(): LazyDataFrame<S>;
   /**
    * Aggregate the columns in the DataFrame to their sum value.
    */
-  sum(): LazyDataFrame;
+  sum(): LazyDataFrame<S>;
   /**
    * Get the last `n` rows of the DataFrame.
    * @see {@link DataFrame.tail}
    */
-  tail(length?: number): LazyDataFrame;
+  tail(length?: number): LazyDataFrame<S>;
   /**
    * compatibility with `JSON.stringify`
    */
@@ -446,16 +472,16 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
     maintainOrder?: boolean,
     subset?: ColumnSelection,
     keep?: "first" | "last",
-  ): LazyDataFrame;
+  ): LazyDataFrame<S>;
   unique(opts: {
     maintainOrder?: boolean;
     subset?: ColumnSelection;
     keep?: "first" | "last";
-  }): LazyDataFrame;
+  }): LazyDataFrame<S>;
   /**
    * Aggregate the columns in the DataFrame to their variance value.
    */
-  var(): LazyDataFrame;
+  var(): LazyDataFrame<S>;
   /**
    * Add or overwrite column in a DataFrame.
    * @param expr - Expression that evaluates to column.
@@ -468,6 +494,10 @@ export interface LazyDataFrame extends Serialize, GroupByOps<LazyGroupBy> {
    */
   withColumns(exprs: (Expr | Series)[]): LazyDataFrame;
   withColumns(...exprs: (Expr | Series)[]): LazyDataFrame;
+  withColumnRenamed<Existing extends keyof S, New extends string>(
+    existing: Existing,
+    replacement: New,
+  ): LazyDataFrame<{ [K in keyof S as K extends Existing ? New : K]: S[K] }>;
   withColumnRenamed(existing: string, replacement: string): LazyDataFrame;
   /**
    * Add a column at index 0 that counts the rows.

--- a/polars/series/index.ts
+++ b/polars/series/index.ts
@@ -1,12 +1,15 @@
 import { DataFrame, _DataFrame } from "../dataframe";
-import { DTYPE_TO_FFINAME, DataType, type Optional } from "../datatypes";
-import type {
-  DTypeToJs,
-  DTypeToJsLoose,
-  DtypeToJsName,
-  JsToDtype,
-  JsType,
-} from "../datatypes/datatype";
+import {
+  type Bool,
+  DTYPE_TO_FFINAME,
+  type DTypeToJs,
+  type DTypeToJsLoose,
+  DataType,
+  type DtypeToJsName,
+  type JsToDtype,
+  type JsType,
+  type Optional,
+} from "../datatypes";
 import { InvalidOperationError } from "../error";
 import { arrayToJsSeries } from "../internals/construction";
 import pli from "../internals/polars_internal";
@@ -142,12 +145,18 @@ export interface Series<T extends DataType = any, Name extends string = string>
   argSort({
     descending,
     nullsLast,
-  }: { descending?: boolean; nullsLast?: boolean }): Series<T, Name>;
+  }: {
+    descending?: boolean;
+    nullsLast?: boolean;
+  }): Series<T, Name>;
   /* @deprecated Use descending instead */
   argSort({
     reverse, // deprecated
     nullsLast,
-  }: { reverse?: boolean; nullsLast?: boolean }): Series<T, Name>;
+  }: {
+    reverse?: boolean;
+    nullsLast?: boolean;
+  }): Series<T, Name>;
   argSort(): Series<T, Name>;
   /**
    * __Rename this Series.__
@@ -410,7 +419,7 @@ export interface Series<T extends DataType = any, Name extends string = string>
   /**
    * Check if this Series is a Boolean.
    */
-  isBoolean(): boolean;
+  isBoolean(): this is Series<Bool>;
   /**
    * Check if this Series is a DataTime.
    */
@@ -512,7 +521,19 @@ export interface Series<T extends DataType = any, Name extends string = string>
   /**
    * Check if this Series datatype is numeric.
    */
-  isNumeric(): boolean;
+  isNumeric(): this is Series<
+    | DataType.Int8
+    | DataType.Int16
+    | DataType.Int32
+    | DataType.Int64
+    | DataType.UInt8
+    | DataType.UInt16
+    | DataType.UInt32
+    | DataType.UInt64
+    | DataType.Float32
+    | DataType.Float64
+    | DataType.Decimal
+  >;
   /**
    * __Get mask of unique values.__
    * ___

--- a/polars/series/string.ts
+++ b/polars/series/string.ts
@@ -291,8 +291,11 @@ export interface SeriesStringFunctions extends StringFunctions<Series> {
    * @param datatype Date or Datetime.
    * @param fmt formatting syntax. [Read more](https://docs.rs/chrono/0.4.19/chrono/format/strptime/index.html)
    */
-  strptime(datatype: DataType.Date, fmt?: string): Series;
-  strptime(datatype: DataType.Datetime, fmt?: string): Series;
+  strptime(datatype: DataType.Date, fmt?: string): Series<DataType.Date>;
+  strptime(
+    datatype: DataType.Datetime,
+    fmt?: string,
+  ): Series<DataType.Datetime>;
   strptime(datatype: typeof DataType.Datetime, fmt?: string): Series;
 }
 

--- a/polars/types.ts
+++ b/polars/types.ts
@@ -1,5 +1,6 @@
 import { DataFrame } from ".";
 import { LazyDataFrame } from "./lazy/dataframe";
+import type { ValueOrArray } from "./utils";
 
 /**
  * Downsample rules
@@ -188,33 +189,78 @@ export type InterpolationMethod =
  */
 export type JoinType = "left" | "inner" | "full" | "semi" | "anti" | "cross";
 
-/** @ignore */
-export type JoinBaseOptions = {
-  how?: JoinType;
+/**
+ * options for same named column join @see {@link DataFrame.join}
+ */
+export type SameNameColumnJoinOptions<
+  L extends string = string,
+  R extends string = string,
+> = {
+  /** Name(s) of the join columns in both DataFrames. */
+  on: ValueOrArray<L & R>;
+  /** Join strategy */
+  how?: Exclude<JoinType, "cross">;
+  /** Suffix to append to columns with a duplicate name. */
+  suffix?: string;
+};
+/**
+ * options for differently named column join @see {@link DataFrame.join}
+ */
+export type DifferentNameColumnJoinOptions<
+  L extends string = string,
+  R extends string = string,
+> = {
+  /** Name(s) of the left join column(s). */
+  leftOn: ValueOrArray<L>;
+  /** Name(s) of the right join column(s). */
+  rightOn: ValueOrArray<R>;
+  /** Join strategy */
+  how?: Exclude<JoinType, "cross">;
+  /** Suffix to append to columns with a duplicate name. */
+  suffix?: string;
+};
+/**
+ * options for cross join @see {@link DataFrame.join}
+ */
+export type CrossJoinOptions = {
+  /** Join strategy */
+  how: "cross";
+  /** Suffix to append to columns with a duplicate name. */
   suffix?: string;
 };
 /**
  * options for join operations @see {@link DataFrame.join}
  */
-export interface JoinOptions {
-  /** left join column */
-  leftOn?: string | Array<string>;
-  /** right join column */
-  rightOn?: string | Array<string>;
-  /** left and right join column */
-  on?: string | Array<string>;
-  /** join type */
-  how?: JoinType;
-  suffix?: string;
-}
+export type JoinOptions<L extends string = string, R extends string = string> =
+  | SameNameColumnJoinOptions<L, R>
+  | DifferentNameColumnJoinOptions<L, R>
+  | CrossJoinOptions;
 
+type LazyJoinBase = {
+  /** Allow the physical plan to optionally evaluate the computation of both DataFrames up to the join in parallel. */
+  allowParallel?: boolean;
+  /** Force the physical plan to evaluate the computation of both DataFrames up to the join in parallel. */
+  forceParallel?: boolean;
+};
+export type LazySameNameColumnJoinOptions<
+  L extends string = string,
+  R extends string = string,
+> = SameNameColumnJoinOptions<L, R> & LazyJoinBase;
+export type LazyDifferentNameColumnJoinOptions<
+  L extends string = string,
+  R extends string = string,
+> = DifferentNameColumnJoinOptions<L, R> & LazyJoinBase;
+export type LazyCrossJoinOptions = CrossJoinOptions & LazyJoinBase;
 /**
  * options for lazy join operations @see {@link LazyDataFrame.join}
  */
-export interface LazyJoinOptions extends JoinOptions {
-  allowParallel?: boolean;
-  forceParallel?: boolean;
-}
+export type LazyJoinOptions<
+  L extends string = string,
+  R extends string = string,
+> =
+  | LazySameNameColumnJoinOptions<L, R>
+  | LazyDifferentNameColumnJoinOptions<L, R>
+  | LazyCrossJoinOptions;
 
 /**
  * options for lazy operations @see {@link LazyDataFrame.collect}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,6 +3053,7 @@ __metadata:
     chance: "npm:^1.1.13"
     jest: "npm:^29.7.0"
     source-map-support: "npm:^0.5.21"
+    ts-expect: "npm:^1.3.0"
     ts-jest: "npm:^29.3.4"
     ts-node: "npm:^10.9.2"
     typedoc: "npm:^0.28.4"
@@ -3679,6 +3680,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10/10dda13571e1f5ad37546827e9b6d4252d2e0bc176c24a101252153ef435d83696e2557fe128c4678e4e78f5f01e83711c703eef9814eb12dab028580d45980a
+  languageName: node
+  linkType: hard
+
+"ts-expect@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "ts-expect@npm:1.3.0"
+  checksum: 10/3f33ba17f9cdad550e9b12a23d78b19836d4fd5741da590c25426ea31ceb8f1765feeeeef2c529bab3e2350b5f9ce5fbbb207012db2c7c4b4b116d1b7fed7ec5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a breaking change.

It feels more natural to express the genericness of a DataFrame through its schema rather than its similarity to a Record of Series. For example, joins then can be computed more easily, as we don't need to unpack each Series to rename them.