### PR TITLE
bug: Renaming commentChar to commentPrefix

### DIFF
--- a/__tests__/io.test.ts
+++ b/__tests__/io.test.ts
@@ -177,6 +177,10 @@ describe("read:csv", () => {
     const df2 = pl.readCSV(csv, { dtypes: { a: pl.Utf8 } });
     expect(df2.dtypes[0].equals(pl.String)).toBeTruthy();
   });
+  test("csv with commentPrefix", () => {
+    const df = pl.readCSV(csvpath, { commentPrefix: "vegetables" });
+    expect(df.shape).toEqual({ height: 20, width: 4 });
+  });
   it.todo("can read from a stream");
 });
 

--- a/polars/io.ts
+++ b/polars/io.ts
@@ -23,7 +23,7 @@ export interface ReadCsvOptions {
   numThreads: number;
   dtypes: Record<string, DataType>;
   lowMemory: boolean;
-  commentChar: string;
+  commentPrefix: string;
   quoteChar: string;
   eolChar: string;
   nullValues: string | Array<string> | Record<string, string>;
@@ -167,7 +167,7 @@ export function readRecords(
  * @param options.dtype -Overwrite the dtypes during inference.
  * @param options.schema -Set the CSV file's schema. This only accepts datatypes that are implemented in the csv parser and expects a complete Schema.
  * @param options.lowMemory - Reduce memory usage in expense of performance.
- * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
+ * @param options.commentPrefix - character that indicates the start of a comment line, for instance '#'.
  * @param options.quoteChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
  * @param options.nullValues - Values to interpret as null values. You can provide a
  *     - `string` -> all values encountered equal to this string will be null
@@ -205,7 +205,7 @@ export function readCSV(pathOrBody, options?) {
 export interface ScanCsvOptions {
   hasHeader: boolean;
   sep: string;
-  commentChar: string;
+  commentPrefix: string;
   quoteChar: string;
   skipRows: number;
   nullValues: string | Array<string> | Record<string, string>;
@@ -251,7 +251,7 @@ const scanCsvDefaultOptions: Partial<ScanCsvOptions> = {
  * @param options.hasHeader - Indicate if first row of dataset is header or not. If set to False first row will be set to `column_x`,
  *     `x` being an enumeration over every column in the dataset.
  * @param options.sep -Character to use as delimiter in the file.
- * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
+ * @param options.commentPrefix - character that indicates the start of a comment line, for instance '#'.
  * @param options.quoteChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
  * @param options.skipRows -Start reading after `skipRows` position.
  * @param options.nullValues - Values to interpret as null values. You can provide a
@@ -631,7 +631,7 @@ export function scanIPC(path, options = {}) {
  * @param options.numThreads -Number of threads to use in csv parsing. Defaults to the number of physical cpu's of your system.
  * @param options.dtype -Overwrite the dtypes during inference.
  * @param options.lowMemory - Reduce memory usage in expense of performance.
- * @param options.commentChar - character that indicates the start of a comment line, for instance '#'.
+ * @param options.commentPrefix - character that indicates the start of a comment line, for instance '#'.
  * @param options.quoteChar -character that is used for csv quoting, default = ''. Set to null to turn special handling and escaping of quotes off.
  * @param options.nullValues - Values to interpret as null values. You can provide a
  *     - `string` -> all values encountered equal to this string will be null

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -67,7 +67,7 @@ pub struct ReadCsvOptions {
     pub path: Option<String>,
     pub dtypes: Option<HashMap<String, Wrap<DataType>>>,
     pub chunk_size: u32,
-    pub comment_char: Option<String>,
+    pub comment_prefix: Option<String>,
     pub null_values: Option<Wrap<NullValues>>,
     pub quote_char: Option<String>,
     pub skip_rows_after_header: u32,
@@ -145,7 +145,7 @@ fn mmap_reader_to_df<'a>(
                 .with_separator(options.sep.unwrap_or(",".to_owned()).as_bytes()[0])
                 .with_encoding(encoding)
                 .with_missing_is_null(options.missing_is_null)
-                .with_comment_prefix(options.comment_char.as_deref())
+                .with_comment_prefix(options.comment_prefix.as_deref())
                 .with_null_values(null_values)
                 .with_try_parse_dates(options.try_parse_dates)
                 .with_quote_char(quote_char)


### PR DESCRIPTION
Renaming commentChar to commentPrefix to match PY-Polars and to close #334 