### PR TITLE
chore: Version 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nodejs-polars"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Cory Grinstead"]
 documentation = "https://pola-rs.github.io/polars-book/"
 edition = "2021"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "repository": "https://github.com/pola-rs/nodejs-polars.git",
   "license": "MIT",
   "main": "bin/index.js",


### PR DESCRIPTION
Since we have not released rs-0.46 yet, this version will release current code from main.