### PR TITLE
Reverting --use-napi-cross for x86_64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/create-js-release.yaml
+++ b/.github/workflows/create-js-release.yaml
@@ -32,7 +32,7 @@ jobs:
             build: |-
               set -e &&
               rustup target add x86_64-unknown-linux-gnu &&
-              yarn build --use-napi-cross --target x86_64-unknown-linux-gnu && llvm-strip -x polars/*.node
+              yarn build -x --target x86_64-unknown-linux-gnu && llvm-strip -x polars/*.node
 
           - host: ubuntu-latest
             architecture: x64


### PR DESCRIPTION
Reverting --use-napi-cross for x86_64-unknown-linux-gnu since it was causing `is compressed with ELFCOMPRESS_ZLIB, but lld is not built with zlib support` linker error