### PR TITLE
ci: update release workflow to use trusted publishing

### DIFF
--- a/.github/workflows/create-js-release.yaml
+++ b/.github/workflows/create-js-release.yaml
@@ -8,6 +8,10 @@ env:
     # Sequence of patterns matched against refs/tags
     tags:
       - "nodejs-polars-v*" # Push events to matching nodejs-polars-v*, i.e. nodejs-polars-v1.0, nodejs-polars-v20.15.10
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -201,5 +205,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
npm had some supply chain attacks so they've been beefing up security on publishing. The release `NPM_TOKEN` is about to expire, and the preferred way now is to use trusted publishers instead of auth tokens.


see: https://docs.npmjs.com/trusted-publishers

