### PR TITLE
chore: minor release 0.23.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nodejs-polars"
-version = "0.23.1"
+version = "0.23.2"
 authors = ["Cory Grinstead"]
 documentation = "https://pola-rs.github.io/polars-book/"
 edition = "2021"

--- a/npm/android-arm64/package.json
+++ b/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars-android-arm64",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "os": [
     "android"
   ],

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars-darwin-arm64",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars-darwin-x64",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "os": [
     "darwin"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars-linux-arm64-gnu",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars-linux-arm64-musl",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars-linux-x64-gnu",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars-linux-x64-musl",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "os": [
     "linux"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars-win32-x64-msvc",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "os": [
     "win32"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-polars",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "repository": "https://github.com/pola-rs/nodejs-polars.git",
   "license": "MIT",
   "main": "bin/index.js",


### PR DESCRIPTION
New minor version 0.23.2 b/c I am unable to publish the last one due to npm error You cannot publish over the previously published versions: 0.23.1.